### PR TITLE
Build graph from IMDb tsv.gz files directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ secrets.py
 db.sqlite3
 data/*.gz
 data/professional.pkl
+data/*_pagerank.pkl
+

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ Thumbs.db
 secrets.py
 db.sqlite3
 data/*.gz
+data/professional.pkl

--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ vertices are people and movies. People are connected to movies and movies are co
 The edges are movie credits, that is an edge exists between a person and a movie if that person appeared in the credits
 for that movie. In this case, we consider only edges which correspond to contributing to a movie as an actor, actress, 
 writer, director or producer. The professional graph is the connected component which contains Fred Astaire.
+
+## PageRank experiments
+To compute the PageRank of the professional graph computed earlier
+
+    ./manage.py runscript page_rank

--- a/README.md
+++ b/README.md
@@ -21,9 +21,17 @@ to see how the results change.
 For some of us, playing this kind of game is actually much more fun than watching the movies themselves.
 
 ## To begin
-Install dependencies from `requirements.txt`. These instructions assume you have virtualenvwrapper installed.
+Install dependencies from `requirements.txt`. With Anaconda create an environment by
+
+    conda create -n cinema python=3
+    conda activate cinema 
+
+To create an environment with virtualenvwrapper
 
     mkvirtualenv -p python3 cinema
+
+Either way, continue with
+    
     pip install -r requirements.txt
     ./manage.py migrate
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# cinema_game
-Cinema game
+# Cinema Game
+Cinema Game is not a commercial product and has never been deployed to production. It began as a limited experiment to 
+measure how humans could understand a profession network graph. Try to answer the following question. What is the 
+shortest path between Brad Pitt and Colin Firth? Consider two actors to be connected and if they have appeared in the 
+same movie and two movies to be connected if at least one appeared in both. There is a path which connects these two 
+actors.
+
+If two actors have appeared in the same movie, then they are considered directly connected, with a path of length 1. 
+The distance between two actors can only decrease, but at the time we first asked this question, there was a path 
+of length 2 between Brad Pitt and Colin Firth. Brad Pitt and Michael Fassbender were both in 12 Years a Slave. Michael 
+Fassbender and Nicholas Hoult were both in X-Men: Apocalypse. Nicholas Hoult and Colin Firth were both in A Single Man.  
+
+The code here is capable of building a professional graph from the data base which IMDb has courteously provided for 
+educators and researchers. With small modification, it can also produce a graph from similar databases such as citation 
+data for scholarly research papers or musical discographies.
+
+For now, we have performed some small experiments, but already there are some intriguing results. Please, give this a 
+try. Compute the PageRank for various subsets of the movie and television professional graph. Try reweighting the edges 
+to see how the results change.
+
+For some of us, playing this kind of game is actually much more fun than watching the movies themselves.
+
+## To begin
+Install dependencies from `requirements.txt`. These instructions assume you have virtualenvwrapper installed.
+
+    mkvirtualenv -p python3 cinema
+    pip install -r requirements.txt
+    ./manage.py migrate
+
+That much will set up the Django project. Downloading data and constructing a professional graph will probably require 
+about 16GB RAM.
+
+    ./manage.py runscript make_imdb_professional_graph
+
+That will create a pickle file of a networkx graph called `data/professional.pkl`. That graph is a bipartite graph whose
+vertices are people and movies. People are connected to movies and movies are connected to people (hence, bipartite).
+The edges are movie credits, that is an edge exists between a person and a movie if that person appeared in the credits
+for that movie. In this case, we consider only edges which correspond to contributing to a movie as an actor, actress, 
+writer, director or producer. The professional graph is the connected component which contains Fred Astaire.

--- a/cinema/cinegraph/fame.py
+++ b/cinema/cinegraph/fame.py
@@ -37,7 +37,7 @@ def fame_by_pagerank(g: nx.Graph, people=None, pagerank=None):
 def works_by_pagerank(g: nx.Graph, works=None, pagerank=None):
     if works is None:
         works = get_works(g)
-    if pagerank is None:    
+    if pagerank is None:
         pagerank = nx.pagerank(g)
     works_pagerank = [(work, pagerank[work]) for work in works]
     sort_by_fame(works_pagerank)
@@ -57,7 +57,12 @@ def normalized_exponential_decay(n, exponent=murdock_exponent):
     return x / x.sum()
 
 
-def weight_by_cast_order(g, ia_s3):
+def weight_zero(g, weight="weight"):
+    for edge in g.edges:
+        g.edges[edge][weight] = 0
+
+
+def weight_by_cast_order(g, ia_s3, weight="weight"):
     d = dict()
 
     for node in get_works(g):
@@ -68,16 +73,10 @@ def weight_by_cast_order(g, ia_s3):
             edge = (PersonNode(actor.getID()), node)
             d[edge] = x[i]
 
-    for edge in g.edges:
-        g.edges[edge]["weight"] = 0
+    weight_zero(g, weight=weight)
 
     for edge, w in d.items():
-        g.edges[edge]["weight"] = w
-
-
-def weight_zero(g):
-    for edge in g.edges:
-        g.edges[edge]["weight"] = 0
+        g.edges[edge][weight] = w
 
 
 def weight_by_order(g, nodes, sort_nodes):
@@ -95,3 +94,18 @@ def weight_by_feature_order(g, nodes, get_feature):
         neighbors.sort(key=get_feature, reverse=True)
 
     weight_by_order(g, nodes, sort_by_feature)
+
+
+def person_work(edge):
+    if edge[0].is_person:
+        p, w = edge
+    else:
+        w, p = edge
+    return p, w
+
+
+def weight_by_function(g, f, weight="weight"):
+    weight_zero(g, weight=weight)
+    for edge in g.edges:
+        p, w = person_work(edge)
+        g.edges[edge][weight] = f(p, w)

--- a/cinema/cinegraph/imdb_tsv.py
+++ b/cinema/cinegraph/imdb_tsv.py
@@ -97,3 +97,31 @@ def addContribution(g, row):
         g.edges[(person, work)]["contributions"].update(contributions)
     else:
         g.add_edge(person, work, contributions=contributions)
+
+
+def hasProfession(g, p, profession):
+    if p not in g.nodes:
+        return False
+    return profession in g.nodes[p]["professions"]
+
+
+def isActor(g, p):
+    return hasProfession(g, p, "actor")
+
+
+def isActress(g, p):
+    return hasProfession(g, p, "actress")
+
+
+def didActing(g, p):
+    return isActor(g, p) or isActress(g, p)
+
+
+def contributedAs(g, p, t, profession):
+    if (p, t) not in g.edges:
+        return False
+    return profession in g.edges[(p, t)]["contributions"].keys()
+
+
+def actedIn(g, p, t):
+    return contributedAs(g, p, t, "actor") or contributedAs(g, p, t, "actress")

--- a/cinema/cinegraph/imdb_tsv.py
+++ b/cinema/cinegraph/imdb_tsv.py
@@ -125,14 +125,20 @@ def acted_in(e):
 
 
 def get_order(e):
-    return e["ordering"]
+    if "ordering" not in e:
+        return 10
+    return min(10, e["ordering"])
 
 
 def get_rating(n):
+    if "rating" not in n:
+        return 0
     return n["rating"]
 
 
 def get_votes(n):
+    if "votes" not in n:
+        return 0
     return n["votes"]
 
 

--- a/cinema/cinegraph/imdb_tsv.py
+++ b/cinema/cinegraph/imdb_tsv.py
@@ -1,0 +1,99 @@
+import pandas as pd
+
+from cinema import directories
+from cinema.cinegraph.grapher import PersonNode, WorkNode
+
+
+class IMDbPersonNode(PersonNode):
+    def __init__(self, nconst):
+        PersonNode.__init__(self, int(nconst[2:]))
+
+
+class IMDbWorkNode(WorkNode):
+    def __init__(self, tconst):
+        WorkNode.__init__(self, int(tconst[2:]))
+
+
+def load_names():
+    return pd.read_csv(
+        directories.data("name.basics.tsv.gz"), compression="gzip", sep="\t"
+    )
+
+
+def load_basics():
+    return pd.read_csv(
+        directories.data("title.basics.tsv.gz"),
+        compression="gzip",
+        sep="\t",
+        low_memory=False,
+    )
+
+
+def load_ratings():
+    return pd.read_csv(
+        directories.data("title.ratings.tsv.gz"), compression="gzip", sep="\t"
+    )
+
+
+def load_principals():
+    return pd.read_csv(
+        directories.data("title.principals.tsv.gz"), compression="gzip", sep="\t"
+    )
+
+
+def addPerson(g, row):
+    person = IMDbPersonNode(row["nconst"])
+    try:
+        known = {IMDbWorkNode(tt) for tt in row["knownForTitles"].split(",")}
+    except ValueError as err:
+        known = {}
+    try:
+        professions = set(row["primaryProfession"].split(","))
+    except AttributeError as err:
+        professions = {}
+    g.add_node(
+        person,
+        name=row["primaryName"],
+        birth=row["birthYear"],
+        death=row["deathYear"],
+        professions=professions,
+        known=known,
+    )
+
+
+def addWork(g, row):
+    work = IMDbWorkNode(row["tconst"])
+    try:
+        genres = set(row["genres"].split(","))
+    except AttributeError as err:
+        genres = {}
+    g.add_node(
+        work,
+        title=row["primaryTitle"],
+        adult=row["isAdult"],
+        start=row["startYear"],
+        end=row["endYear"],
+        runtime=row["runtimeMinutes"],
+        genres=genres,
+    )
+
+
+def updateRating(g, row):
+    work = IMDbWorkNode(row["tconst"])
+    if work not in g:
+        return
+    update = {"rating": row["averageRating"], "votes": row["numVotes"]}
+    g.nodes[work].update(update)
+
+
+def addContribution(g, row):
+    person = IMDbPersonNode(row["nconst"])
+    work = IMDbWorkNode(row["tconst"])
+    if not (person in g.nodes and work in g.nodes):
+        return
+    contribution = {"ordering": row["ordering"], "job": row["job"]}
+    contributions = {row["category"]: contribution}
+    if (person, work) in g.edges:
+        g.edges[(person, work)]["contributions"].update(contributions)
+    else:
+        g.add_edge(person, work, contributions=contributions)

--- a/cinema/cinegraph/weights.py
+++ b/cinema/cinegraph/weights.py
@@ -1,0 +1,73 @@
+import math
+import numpy as np
+
+from cinema.cinegraph import fame
+from cinema.cinegraph import imdb_tsv
+
+
+def credit_order_weight(order):
+    return math.tanh((1 - order) / 3) + 1
+
+
+def rating_weight(rating):
+    return rating / 10.0
+
+
+def normalized_activation(y):
+    return 0.5 * (math.tanh(y) + 1)
+
+
+def node_mean_std(g, f, pred):
+    x = np.array([f(g.nodes[n]) for n in g.nodes if pred(n, g.nodes[n])])
+    return np.mean(x), np.std(x)
+
+
+def votes_mean_std(g, get_votes=imdb_tsv.get_votes):
+    return node_mean_std(g, get_votes, lambda n, _: not n.is_person)
+
+
+def weight_by_normalized_votes(g, get_votes=imdb_tsv.get_votes, weight="weight"):
+    mu, sigma = votes_mean_std(g, get_votes=get_votes)
+    fame.weight_by_function(
+        g,
+        lambda p, w: normalized_activation((get_votes(g.nodes[w]) - mu) / sigma),
+        weight=weight,
+    )
+
+
+def weight_only_actors(g, weight="weight", acted_in=imdb_tsv.acted_in):
+    fame.weight_by_function(g, lambda p, w: acted_in(g.edges[(p, w)]), weight=weight)
+
+
+def weight_credit_order(g, get_order=imdb_tsv.get_order, weight="weight"):
+    fame.weight_by_function(
+        g, lambda p, w: credit_order_weight(get_order(g.edges[(p, w)])), weight=weight
+    )
+
+
+def weight_by_rating(g, get_order=imdb_tsv.get_rating, weight="weight"):
+    fame.weight_by_function(
+        g, lambda p, w: rating_weight(get_order(g.nodes[w])), weight=weight
+    )
+
+
+def combine_weights(g, binary_op, weight0, weight1, new_weight=None):
+    if new_weight is None:
+        new_weight = "{}_{}".format(weight0, weight1)
+    for edge in g.edges:
+        g.edges[edge][new_weight] = binary_op(
+            g.edges[edge][weight0], g.edges[edge][weight1]
+        )
+    return new_weight
+
+
+def sum_weights(g, weight0, weight1, new_weight=None):
+    return combine_weights(
+        g, lambda a, b: a + b, weight0, weight1, new_weight=new_weight
+    )
+
+
+def multiply_weights(g, weight0, weight1, new_weight=None):
+    return combine_weights(
+        g, lambda a, b: a * b, weight0, weight1, new_weight=new_weight
+    )

--- a/cinema/core/scripts/make_imdb_professional_graph.py
+++ b/cinema/core/scripts/make_imdb_professional_graph.py
@@ -6,8 +6,12 @@
 import os
 from tqdm import tqdm
 import requests
+import networkx as nx
+import pickle
 
 from cinema import directories
+from cinema.cinegraph import imdb_tsv
+from cinema.cinegraph.grapher import PersonNode
 
 
 def retrieve_imdb_data(filename):
@@ -29,9 +33,75 @@ def retrieve_imdb_data(filename):
     progress_bar.close()
 
 
+def filteredGraphUpdate(g, df, rowUpdate, predicate=None):
+    if predicate is None:
+        predicate = lambda row: True
+    with tqdm(total=len(df)) as pbar:
+        for _, row in df.iterrows():
+            if predicate(row):
+                rowUpdate(g, row)
+            pbar.update(1)
+
+
+def populatePeople(g):
+    relevant = set("actor,actress,writer,director,producer".split(","))
+
+    def predicate(row):
+        primaryProfessions = row["primaryProfession"]
+        try:
+            professions = set(primaryProfessions.split(","))
+        except:
+            return False
+        return not relevant.isdisjoint(professions)
+
+    print("loading people data")
+    df = imdb_tsv.load_names()
+    print("data loaded")
+    filteredGraphUpdate(g, df, imdb_tsv.addPerson, predicate=predicate)
+
+
+def populateMovies(g):
+    print("loading work data")
+    df = imdb_tsv.load_basics()
+    print("data loaded")
+    predicate = lambda row: row["titleType"] == "movie"
+    filteredGraphUpdate(g, df, imdb_tsv.addWork, predicate=predicate)
+
+
+def updateRatings(g):
+    print("loading rating data")
+    df = imdb_tsv.load_ratings()
+    print("data loaded")
+    filteredGraphUpdate(g, df, imdb_tsv.updateRating)
+
+
+def makeEdges(g):
+    print("loading credits data")
+    df = imdb_tsv.load_principals()
+    print("data loaded")
+    relevantJobs = "actor,actress,writer,director,producer".split(",")
+    predicate = lambda row: row["category"] in relevantJobs
+    filteredGraphUpdate(g, df, imdb_tsv.addContribution, predicate=predicate)
+
+
+def makeProfessionalGraph():
+    g = nx.Graph()
+    populatePeople(g)
+    populateMovies(g)
+    updateRatings(g)
+    makeEdges(g)
+    # we want the component with Fred Astaire who has ID 1
+    return g.subgraph(nx.node_connected_component(g, PersonNode(1))).copy()
+
+
 def run():
-    print("hi")
+    print("Downloading data")
     retrieve_imdb_data("name.basics.tsv.gz")
     retrieve_imdb_data("title.basics.tsv.gz")
     retrieve_imdb_data("title.ratings.tsv.gz")
     retrieve_imdb_data("title.principals.tsv.gz")
+
+    print("Creating graph")
+    g = makeProfessionalGraph()
+    with open(directories.data("professional.pkl"), "wb") as f:
+        pickle.dump(g, f)

--- a/cinema/core/scripts/make_imdb_professional_graph.py
+++ b/cinema/core/scripts/make_imdb_professional_graph.py
@@ -1,0 +1,37 @@
+# scripts/make_imdb_professional_graph.py
+# Internet Movie Database Inc. makes publicly available a limited dataset for academic purposes.
+# See https://www.imdb.com/interfaces/
+# Carefully check license to make sure this is matches you intended use.
+
+import os
+from tqdm import tqdm
+import requests
+
+from cinema import directories
+
+
+def retrieve_imdb_data(filename):
+    path = directories.data(filename)
+    print(path)
+    if os.path.exists(path):
+        print("{} already exists".format(path))
+        return
+    url = "https://datasets.imdbws.com/{}".format(filename)
+    print("Down loading {}".format(url))
+    response = requests.get(url, stream=True)
+    total_size_in_bytes = int(response.headers.get("content-length", 0))
+    block_size = 1024
+    progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
+    with open(path, "wb") as f:
+        for data in response.iter_content(block_size):
+            progress_bar.update(len(data))
+            f.write(data)
+    progress_bar.close()
+
+
+def run():
+    print("hi")
+    retrieve_imdb_data("name.basics.tsv.gz")
+    retrieve_imdb_data("title.basics.tsv.gz")
+    retrieve_imdb_data("title.ratings.tsv.gz")
+    retrieve_imdb_data("title.principals.tsv.gz")

--- a/cinema/core/scripts/page_rank.py
+++ b/cinema/core/scripts/page_rank.py
@@ -12,10 +12,10 @@ def full_graph_pr(g):
     return nx.pagerank(g)
 
 
-def show_person(g, rank, p):
+def show_person(g, rank, p, i):
     n = g.nodes[p]
-    s = "{:7.2e} {:>8} {:<25} birth {:>4} death {:>4} {}".format(
-        rank[p], p.id, n["name"], n["birth"], n["death"], n["professions"]
+    s = "{:>3} {:7.2e} {:>8} {:<25} birth {:>4} death {:>4}, {}".format(
+        i, rank[p], p.id, n["name"], n["birth"], n["death"], n["professions"]
     )
     print(s)
 
@@ -28,12 +28,12 @@ def run():
     t0 = time.time()
     print("Computing page rank of full graph. This may take a bit of time")
     rank = full_graph_pr(g)
-    print("PageRank computed in {:.2g} seconds.".format(time.time() - 10))
+    print("PageRank computed in {:.2g} seconds.".format(time.time() - t0))
     nodes = list(g.nodes)
     nodes.sort(key=lambda n: rank[n], reverse=True)
     people = [n for n in nodes if n.is_person]
-    for p in people[:100]:
-        show_person(g, rank, p)
+    for i, p in enumerate(people[:100]):
+        show_person(g, rank, p, i)
     print("Saving page rank dictionary.")
     with open(directories.data("full_graph_pagerank.pkl"), "wb") as f:
         pickle.dump(rank, f)

--- a/cinema/core/scripts/page_rank.py
+++ b/cinema/core/scripts/page_rank.py
@@ -3,6 +3,7 @@
 
 import networkx as nx
 import pickle
+import time
 
 from cinema import directories
 
@@ -20,14 +21,20 @@ def show_person(g, rank, p):
 
 
 def run():
+    print("Loading professional graph.")
     with open(directories.data("professional.pkl"), "rb") as f:
         g = pickle.load(f)
+
+    t0 = time.time()
+    print("Computing page rank of full graph. This may take a bit of time")
     rank = full_graph_pr(g)
+    print("PageRank computed in {:.2g} seconds.".format(time.time() - 10))
     nodes = list(g.nodes)
     nodes.sort(key=lambda n: rank[n], reverse=True)
     people = [n for n in nodes if n.is_person]
     for p in people[:100]:
         show_person(g, rank, p)
-
+    print("Saving page rank dictionary.")
     with open(directories.data("full_graph_pagerank.pkl"), "wb") as f:
         pickle.dump(rank, f)
+    print("Ending script.")

--- a/cinema/core/scripts/page_rank.py
+++ b/cinema/core/scripts/page_rank.py
@@ -5,11 +5,44 @@ import networkx as nx
 import pickle
 import time
 
+from cinema.cinegraph import weights
 from cinema import directories
 
 
 def full_graph_pr(g):
     return nx.pagerank(g)
+
+
+def actor_graph_pr(g):
+    weight = "actor_weight"
+    weights.weight_only_actors(g, weight=weight)
+    return nx.pagerank(g, weight=weight)
+
+
+def credit_order_pr(g):
+    weight = "order_weight"
+    weights.weight_credit_order(g, weight=weight)
+    return nx.pagerank(g, weight=weight)
+
+
+def rating_pr(g):
+    weight = "rating_weight"
+    weights.weight_by_rating(g, weight=weight)
+    return nx.pagerank(g, weight=weight)
+
+
+def votes_pr(g):
+    weight = "votes_weight"
+    weights.weight_by_normalized_votes(g, weight=weight)
+    return nx.pagerank(g, weight=weight)
+
+
+def rating_votes_pr(g):
+    weight = "ratings_votes_weight"
+    weights.multiply_weights(
+        g, weight0="rating_weight", weight1="votes_weight", new_weight=weight
+    )
+    return nx.pagerank(g, weight=weight)
 
 
 def show_person(g, rank, p, i):
@@ -20,21 +53,32 @@ def show_person(g, rank, p, i):
     print(s)
 
 
+def compute_pagerank(g, pageranker, name: str):
+    filename = "{}_pagerank.pkl".format(name.replace(" ", "_"))
+
+    t0 = time.time()
+    print("Computing page rank of {}. This may take a bit of time".format(name))
+    rank = pageranker(g)
+    print("PageRank computed in {:.2g} seconds.".format(time.time() - t0))
+    nodes = list(g.nodes)
+    nodes.sort(key=lambda n: rank[n], reverse=True)
+    people = [n for n in nodes if n.is_person]
+    for i, p in enumerate(people[:25]):
+        show_person(g, rank, p, i)
+    print("Saving page rank dictionary.")
+    with open(directories.data(filename), "wb") as f:
+        pickle.dump(rank, f)
+    print("Saved.\n\n")
+
+
 def run():
     print("Loading professional graph.")
     with open(directories.data("professional.pkl"), "rb") as f:
         g = pickle.load(f)
 
-    t0 = time.time()
-    print("Computing page rank of full graph. This may take a bit of time")
-    rank = full_graph_pr(g)
-    print("PageRank computed in {:.2g} seconds.".format(time.time() - t0))
-    nodes = list(g.nodes)
-    nodes.sort(key=lambda n: rank[n], reverse=True)
-    people = [n for n in nodes if n.is_person]
-    for i, p in enumerate(people[:100]):
-        show_person(g, rank, p, i)
-    print("Saving page rank dictionary.")
-    with open(directories.data("full_graph_pagerank.pkl"), "wb") as f:
-        pickle.dump(rank, f)
-    print("Ending script.")
+    compute_pagerank(g, full_graph_pr, "full graph")
+    compute_pagerank(g, actor_graph_pr, "actor graph")
+    compute_pagerank(g, credit_order_pr, "credit order graph")
+    compute_pagerank(g, rating_pr, "rating graph")
+    compute_pagerank(g, votes_pr, "votes graph")
+    compute_pagerank(g, rating_votes_pr, "rating and votes graph")

--- a/cinema/core/scripts/page_rank.py
+++ b/cinema/core/scripts/page_rank.py
@@ -1,0 +1,33 @@
+# scripts/page_rank.py
+# Compute PageRank of professional graph constructed by make_imdb_professional_graph
+
+import networkx as nx
+import pickle
+
+from cinema import directories
+
+
+def full_graph_pr(g):
+    return nx.pagerank(g)
+
+
+def show_person(g, rank, p):
+    n = g.nodes[p]
+    s = "{:7.2e} {:>8} {:<25} birth {:>4} death {:>4} {}".format(
+        rank[p], p.id, n["name"], n["birth"], n["death"], n["professions"]
+    )
+    print(s)
+
+
+def run():
+    with open(directories.data("professional.pkl"), "rb") as f:
+        g = pickle.load(f)
+    rank = full_graph_pr(g)
+    nodes = list(g.nodes)
+    nodes.sort(key=lambda n: rank[n], reverse=True)
+    people = [n for n in nodes if n.is_person]
+    for p in people[:100]:
+        show_person(g, rank, p)
+
+    with open(directories.data("full_graph_pagerank.pkl"), "wb") as f:
+        pickle.dump(rank, f)

--- a/cinema/generate_key.py
+++ b/cinema/generate_key.py
@@ -1,0 +1,7 @@
+import string
+import secrets
+
+
+def generate_secret_key(n=32):
+    alphabet = string.ascii_letters + string.digits + string.punctuation
+    return "".join(secrets.choice(alphabet) for i in range(n))

--- a/cinema/settings.py
+++ b/cinema/settings.py
@@ -11,7 +11,16 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
-from cinema.secrets import *
+
+try:
+    from cinema.secrets import SECRET_KEY
+except ImportError:
+    from cinema.generate_key import generate_secret_key
+    print("WARNING: cinema/secrets.py not found")
+    print("Make this annoying warning go away by creating secrets.py")
+    print("with SECRET_KEY variable. For example")
+    SECRET_KEY = generate_secret_key(48)
+    print("\n\nSECRET_KEY = {}\n\n".format(repr(SECRET_KEY)))
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/cinema/tests/fixture_imbd_tsv.py
+++ b/cinema/tests/fixture_imbd_tsv.py
@@ -1,0 +1,164 @@
+import networkx as nx
+
+from cinema.cinegraph import imdb_tsv
+
+
+class FixtureIMDbTsv:
+    def setUp(self):
+        self.names = [
+            {
+                "deathYear": "1987",
+                "primaryName": "Fred Astaire",
+                "nconst": "nm0000001",
+                "birthYear": "1899",
+                "knownForTitles": "tt0072308,tt0050419,tt0043044,tt0053137",
+                "primaryProfession": "soundtrack,actor,miscellaneous",
+            },
+            {
+                "deathYear": "2014",
+                "primaryName": "Lauren Bacall",
+                "nconst": "nm0000002",
+                "birthYear": "1924",
+                "knownForTitles": "tt0117057,tt0037382,tt0038355,tt0071877",
+                "primaryProfession": "actress,soundtrack",
+            },
+            {
+                "deathYear": "\\N",
+                "primaryName": "Brigitte Bardot",
+                "nconst": "nm0000003",
+                "birthYear": "1934",
+                "knownForTitles": "tt0049189,tt0059956,tt0057345,tt0054452",
+                "primaryProfession": "actress,soundtrack,producer",
+            },
+            {
+                "primaryName": "Richard Thorpe",
+                "knownForTitles": "tt0015852,tt0044760,tt0043599,tt0045966",
+                "deathYear": "1991",
+                "primaryProfession": "director,writer,actor",
+                "nconst": "nm0861703",
+                "birthYear": "1896",
+            },
+        ]
+        self.basics = [
+            {
+                "runtimeMinutes": "102",
+                "isAdult": 0,
+                "tconst": "tt0043044",
+                "genres": "Biography,Comedy,Musical",
+                "endYear": "\\N",
+                "originalTitle": "Three Little Words",
+                "primaryTitle": "Three Little Words",
+                "startYear": "1950",
+                "titleType": "movie",
+            },
+            {
+                "runtimeMinutes": "103",
+                "isAdult": 0,
+                "tconst": "tt0050419",
+                "genres": "Comedy,Musical,Romance",
+                "endYear": "\\N",
+                "originalTitle": "Funny Face",
+                "primaryTitle": "Funny Face",
+                "startYear": "1957",
+                "titleType": "movie",
+            },
+            {
+                "runtimeMinutes": "134",
+                "isAdult": 0,
+                "tconst": "tt0053137",
+                "genres": "Drama,Romance,Sci-Fi",
+                "endYear": "\\N",
+                "originalTitle": "On the Beach",
+                "primaryTitle": "On the Beach",
+                "startYear": "1959",
+                "titleType": "movie",
+            },
+            {
+                "isAdult": 0,
+                "runtimeMinutes": "126",
+                "genres": "Comedy,Drama,Romance",
+                "titleType": "movie",
+                "endYear": "\\N",
+                "tconst": "tt0117057",
+                "primaryTitle": "The Mirror Has Two Faces",
+                "startYear": "1996",
+                "originalTitle": "The Mirror Has Two Faces",
+            },
+        ]
+        self.ratings = [
+            {"averageRating": 6.9, "tconst": "tt0043044", "numVotes": 1497},
+            {"averageRating": 7.0, "tconst": "tt0050419", "numVotes": 24896},
+            {"averageRating": 7.2, "tconst": "tt0053137", "numVotes": 11261},
+            {"averageRating": 6.9, "tconst": "tt0072308", "numVotes": 36833},
+            {"tconst": "tt0117057", "numVotes": 14369, "averageRating": 6.6},
+        ]
+        self.principals = [
+            {
+                "ordering": 10,
+                "job": "\\N",
+                "tconst": "tt0043044",
+                "nconst": "nm0943978",
+                "category": "actor",
+                "characters": '["Charlie Kope"]',
+            },
+            {
+                "category": "director",
+                "ordering": 5,
+                "characters": "\\N",
+                "tconst": "tt0043044",
+                "nconst": "nm0861703",
+                "job": "\\N",
+            },
+            {
+                "ordering": 1,
+                "job": "\\N",
+                "tconst": "tt0043044",
+                "nconst": "nm0000001",
+                "category": "actor",
+                "characters": '["Bert Kalmar"]',
+            },
+            {
+                "ordering": 1,
+                "job": "\\N",
+                "tconst": "tt0050419",
+                "nconst": "nm0000030",
+                "category": "actress",
+                "characters": '["Jo Stockton"]',
+            },
+            {
+                "ordering": 2,
+                "job": "\\N",
+                "tconst": "tt0050419",
+                "nconst": "nm0000001",
+                "category": "actor",
+                "characters": '["Dick Avery"]',
+            },
+            {
+                "ordering": 9,
+                "job": "screenplay",
+                "tconst": "tt0072308",
+                "nconst": "nm0798103",
+                "category": "writer",
+                "characters": "\\N",
+            },
+            {
+                "category": "actress",
+                "ordering": 3,
+                "characters": '["Hannah Morgan"]',
+                "tconst": "tt0117057",
+                "nconst": "nm0000002",
+                "job": "\\N",
+            },
+        ]
+
+    def make_graph(self):
+        g = nx.Graph()
+        for person in self.names:
+            imdb_tsv.add_person(g, person)
+        for work in self.basics:
+            imdb_tsv.add_work(g, work)
+        for rating in self.ratings:
+            imdb_tsv.update_rating(g, rating)
+        for credit in self.principals:
+            imdb_tsv.add_contribution(g, credit)
+        return g

--- a/cinema/tests/test_fame.py
+++ b/cinema/tests/test_fame.py
@@ -5,7 +5,7 @@ from numpy.linalg import norm
 
 from cinema.cinegraph.grapher import PersonNode, WorkNode
 from cinema.tests import data4tests
-from cinema.cinegame import fame
+from cinema.cinegraph import fame
 
 
 class TestFame(TestCase):

--- a/cinema/tests/test_fame.py
+++ b/cinema/tests/test_fame.py
@@ -47,7 +47,7 @@ class TestFame(TestCase):
         expected = [57, 56, 50, 46]
         self.assertEqual(expected, actual)
 
-    def test_fame_by_pageranks(self):
+    def test_fame_by_pagerank(self):
         g = data4tests.get_small_graph()
         people_rank, _ = fame.fame_by_pagerank(g)
         actual = [p for p, _ in people_rank[:4]]

--- a/cinema/tests/test_imdb_tsv.py
+++ b/cinema/tests/test_imdb_tsv.py
@@ -1,0 +1,198 @@
+from django.test import TestCase
+
+import numpy as np
+import networkx as nx
+from numpy.linalg import norm
+
+from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph import imdb_tsv
+from cinema.tests import data4tests
+
+
+class TestIMDbTsv(TestCase):
+    def setUp(self):
+        self.names = [
+            {
+                "deathYear": "1987",
+                "primaryName": "Fred Astaire",
+                "nconst": "nm0000001",
+                "birthYear": "1899",
+                "knownForTitles": "tt0072308,tt0050419,tt0043044,tt0053137",
+                "primaryProfession": "soundtrack,actor,miscellaneous",
+            },
+            {
+                "deathYear": "2014",
+                "primaryName": "Lauren Bacall",
+                "nconst": "nm0000002",
+                "birthYear": "1924",
+                "knownForTitles": "tt0117057,tt0037382,tt0038355,tt0071877",
+                "primaryProfession": "actress,soundtrack",
+            },
+            {
+                "deathYear": "\\N",
+                "primaryName": "Brigitte Bardot",
+                "nconst": "nm0000003",
+                "birthYear": "1934",
+                "knownForTitles": "tt0049189,tt0059956,tt0057345,tt0054452",
+                "primaryProfession": "actress,soundtrack,producer",
+            },
+        ]
+        self.basics = [
+            {
+                "runtimeMinutes": "102",
+                "isAdult": 0,
+                "tconst": "tt0043044",
+                "genres": "Biography,Comedy,Musical",
+                "endYear": "\\N",
+                "originalTitle": "Three Little Words",
+                "primaryTitle": "Three Little Words",
+                "startYear": "1950",
+                "titleType": "movie",
+            },
+            {
+                "runtimeMinutes": "103",
+                "isAdult": 0,
+                "tconst": "tt0050419",
+                "genres": "Comedy,Musical,Romance",
+                "endYear": "\\N",
+                "originalTitle": "Funny Face",
+                "primaryTitle": "Funny Face",
+                "startYear": "1957",
+                "titleType": "movie",
+            },
+            {
+                "runtimeMinutes": "134",
+                "isAdult": 0,
+                "tconst": "tt0053137",
+                "genres": "Drama,Romance,Sci-Fi",
+                "endYear": "\\N",
+                "originalTitle": "On the Beach",
+                "primaryTitle": "On the Beach",
+                "startYear": "1959",
+                "titleType": "movie",
+            },
+        ]
+        self.ratings = [
+            {"averageRating": 6.9, "tconst": "tt0043044", "numVotes": 1497},
+            {"averageRating": 7.0, "tconst": "tt0050419", "numVotes": 24896},
+            {"averageRating": 7.2, "tconst": "tt0053137", "numVotes": 11261},
+            {"averageRating": 6.9, "tconst": "tt0072308", "numVotes": 36833},
+        ]
+        self.principals = [
+            {
+                "ordering": 10,
+                "job": "\\N",
+                "tconst": "tt0043044",
+                "nconst": "nm0943978",
+                "category": "actor",
+                "characters": '["Charlie Kope"]',
+            },
+            {
+                "ordering": 1,
+                "job": "\\N",
+                "tconst": "tt0043044",
+                "nconst": "nm0000001",
+                "category": "actor",
+                "characters": '["Bert Kalmar"]',
+            },
+            {
+                "ordering": 1,
+                "job": "\\N",
+                "tconst": "tt0050419",
+                "nconst": "nm0000030",
+                "category": "actress",
+                "characters": '["Jo Stockton"]',
+            },
+            {
+                "ordering": 2,
+                "job": "\\N",
+                "tconst": "tt0050419",
+                "nconst": "nm0000001",
+                "category": "actor",
+                "characters": '["Dick Avery"]',
+            },
+            {
+                "ordering": 9,
+                "job": "screenplay",
+                "tconst": "tt0072308",
+                "nconst": "nm0798103",
+                "category": "writer",
+                "characters": "\\N",
+            },
+        ]
+
+    def tearDown(self):
+        pass
+
+    def test_person_node(self):
+        fred = imdb_tsv.IMDbPersonNode("nm0000001")
+        self.assertEqual(1, fred.id)
+        self.assertTrue(fred.is_person)
+
+    def test_work_node(self):
+        three_little_words = imdb_tsv.IMDbWorkNode("tt0043044")
+        self.assertEqual(43044, three_little_words.id)
+        self.assertFalse(three_little_words.is_person)
+
+    def test_add_person(self):
+        g = nx.Graph()
+        imdb_tsv.addPerson(g, self.names[0])
+        expected = {
+            "name": "Fred Astaire",
+            "birth": "1899",
+            "death": "1987",
+            "professions": {"miscellaneous", "actor", "soundtrack"},
+            "known": {
+                WorkNode(53137),
+                WorkNode(50419),
+                WorkNode(72308),
+                WorkNode(43044),
+            },
+        }
+        actual = g.nodes[PersonNode(1)]
+        self.assertEqual(expected, actual)
+
+    def test_add_work(self):
+        g = nx.Graph()
+        imdb_tsv.addWork(g, self.basics[0])
+        expected = {
+            "title": "Three Little Words",
+            "adult": 0,
+            "start": "1950",
+            "end": "\\N",
+            "runtime": "102",
+            "genres": {"Biography", "Musical", "Comedy"},
+        }
+        actual = g.nodes[WorkNode(43044)]
+        self.assertEqual(expected, actual)
+
+    def test_update_rating(self):
+        g = nx.Graph()
+        imdb_tsv.addWork(g, self.basics[0])
+        imdb_tsv.updateRating(g, self.ratings[0])
+        expected = {
+            "title": "Three Little Words",
+            "adult": 0,
+            "start": "1950",
+            "end": "\\N",
+            "runtime": "102",
+            "genres": {"Musical", "Comedy", "Biography"},
+            "rating": 6.9,
+            "votes": 1497,
+        }
+        actual = g.nodes[WorkNode(43044)]
+        self.assertEqual(expected, actual)
+
+    def test_add_contribution(self):
+        g = nx.Graph()
+        for person in self.names:
+            imdb_tsv.addPerson(g, person)
+        for work in self.basics:
+            imdb_tsv.addWork(g, work)
+        for rating in self.ratings:
+            imdb_tsv.updateRating(g, rating)
+        for credit in self.principals:
+            imdb_tsv.addContribution(g, credit)
+        expected = {"contributions": {"actor": {"ordering": 1, "job": "\\N"}}}
+        actual = g.edges[(PersonNode(1), WorkNode(43044))]
+        self.assertEqual(expected, actual)

--- a/cinema/tests/test_imdb_tsv.py
+++ b/cinema/tests/test_imdb_tsv.py
@@ -2,172 +2,17 @@ from django.test import TestCase
 
 import networkx as nx
 
+from cinema.tests.fixture_imbd_tsv import FixtureIMDbTsv
 from cinema.cinegraph.grapher import PersonNode, WorkNode
 from cinema.cinegraph import imdb_tsv
 
 
-class TestIMDbTsv(TestCase):
+class TestIMDbTsv(TestCase, FixtureIMDbTsv):
     def setUp(self):
-        self.names = [
-            {
-                "deathYear": "1987",
-                "primaryName": "Fred Astaire",
-                "nconst": "nm0000001",
-                "birthYear": "1899",
-                "knownForTitles": "tt0072308,tt0050419,tt0043044,tt0053137",
-                "primaryProfession": "soundtrack,actor,miscellaneous",
-            },
-            {
-                "deathYear": "2014",
-                "primaryName": "Lauren Bacall",
-                "nconst": "nm0000002",
-                "birthYear": "1924",
-                "knownForTitles": "tt0117057,tt0037382,tt0038355,tt0071877",
-                "primaryProfession": "actress,soundtrack",
-            },
-            {
-                "deathYear": "\\N",
-                "primaryName": "Brigitte Bardot",
-                "nconst": "nm0000003",
-                "birthYear": "1934",
-                "knownForTitles": "tt0049189,tt0059956,tt0057345,tt0054452",
-                "primaryProfession": "actress,soundtrack,producer",
-            },
-            {
-                "primaryName": "Richard Thorpe",
-                "knownForTitles": "tt0015852,tt0044760,tt0043599,tt0045966",
-                "deathYear": "1991",
-                "primaryProfession": "director,writer,actor",
-                "nconst": "nm0861703",
-                "birthYear": "1896",
-            },
-        ]
-        self.basics = [
-            {
-                "runtimeMinutes": "102",
-                "isAdult": 0,
-                "tconst": "tt0043044",
-                "genres": "Biography,Comedy,Musical",
-                "endYear": "\\N",
-                "originalTitle": "Three Little Words",
-                "primaryTitle": "Three Little Words",
-                "startYear": "1950",
-                "titleType": "movie",
-            },
-            {
-                "runtimeMinutes": "103",
-                "isAdult": 0,
-                "tconst": "tt0050419",
-                "genres": "Comedy,Musical,Romance",
-                "endYear": "\\N",
-                "originalTitle": "Funny Face",
-                "primaryTitle": "Funny Face",
-                "startYear": "1957",
-                "titleType": "movie",
-            },
-            {
-                "runtimeMinutes": "134",
-                "isAdult": 0,
-                "tconst": "tt0053137",
-                "genres": "Drama,Romance,Sci-Fi",
-                "endYear": "\\N",
-                "originalTitle": "On the Beach",
-                "primaryTitle": "On the Beach",
-                "startYear": "1959",
-                "titleType": "movie",
-            },
-            {
-                "isAdult": 0,
-                "runtimeMinutes": "126",
-                "genres": "Comedy,Drama,Romance",
-                "titleType": "movie",
-                "endYear": "\\N",
-                "tconst": "tt0117057",
-                "primaryTitle": "The Mirror Has Two Faces",
-                "startYear": "1996",
-                "originalTitle": "The Mirror Has Two Faces",
-            },
-        ]
-        self.ratings = [
-            {"averageRating": 6.9, "tconst": "tt0043044", "numVotes": 1497},
-            {"averageRating": 7.0, "tconst": "tt0050419", "numVotes": 24896},
-            {"averageRating": 7.2, "tconst": "tt0053137", "numVotes": 11261},
-            {"averageRating": 6.9, "tconst": "tt0072308", "numVotes": 36833},
-            {"tconst": "tt0117057", "numVotes": 14369, "averageRating": 6.6},
-        ]
-        self.principals = [
-            {
-                "ordering": 10,
-                "job": "\\N",
-                "tconst": "tt0043044",
-                "nconst": "nm0943978",
-                "category": "actor",
-                "characters": '["Charlie Kope"]',
-            },
-            {
-                "category": "director",
-                "ordering": 5,
-                "characters": "\\N",
-                "tconst": "tt0043044",
-                "nconst": "nm0861703",
-                "job": "\\N",
-            },
-            {
-                "ordering": 1,
-                "job": "\\N",
-                "tconst": "tt0043044",
-                "nconst": "nm0000001",
-                "category": "actor",
-                "characters": '["Bert Kalmar"]',
-            },
-            {
-                "ordering": 1,
-                "job": "\\N",
-                "tconst": "tt0050419",
-                "nconst": "nm0000030",
-                "category": "actress",
-                "characters": '["Jo Stockton"]',
-            },
-            {
-                "ordering": 2,
-                "job": "\\N",
-                "tconst": "tt0050419",
-                "nconst": "nm0000001",
-                "category": "actor",
-                "characters": '["Dick Avery"]',
-            },
-            {
-                "ordering": 9,
-                "job": "screenplay",
-                "tconst": "tt0072308",
-                "nconst": "nm0798103",
-                "category": "writer",
-                "characters": "\\N",
-            },
-            {
-                "category": "actress",
-                "ordering": 3,
-                "characters": '["Hannah Morgan"]',
-                "tconst": "tt0117057",
-                "nconst": "nm0000002",
-                "job": "\\N",
-            },
-        ]
+        FixtureIMDbTsv.setUp(self)
 
     def tearDown(self):
         pass
-
-    def make_graph(self):
-        g = nx.Graph()
-        for person in self.names:
-            imdb_tsv.addPerson(g, person)
-        for work in self.basics:
-            imdb_tsv.addWork(g, work)
-        for rating in self.ratings:
-            imdb_tsv.updateRating(g, rating)
-        for credit in self.principals:
-            imdb_tsv.addContribution(g, credit)
-        return g
 
     def test_person_node(self):
         fred = imdb_tsv.IMDbPersonNode("nm0000001")
@@ -181,7 +26,7 @@ class TestIMDbTsv(TestCase):
 
     def test_add_person(self):
         g = nx.Graph()
-        imdb_tsv.addPerson(g, self.names[0])
+        imdb_tsv.add_person(g, self.names[0])
         expected = {
             "name": "Fred Astaire",
             "birth": "1899",
@@ -199,7 +44,7 @@ class TestIMDbTsv(TestCase):
 
     def test_add_work(self):
         g = nx.Graph()
-        imdb_tsv.addWork(g, self.basics[0])
+        imdb_tsv.add_work(g, self.basics[0])
         expected = {
             "title": "Three Little Words",
             "adult": 0,
@@ -213,8 +58,8 @@ class TestIMDbTsv(TestCase):
 
     def test_update_rating(self):
         g = nx.Graph()
-        imdb_tsv.addWork(g, self.basics[0])
-        imdb_tsv.updateRating(g, self.ratings[0])
+        imdb_tsv.add_work(g, self.basics[0])
+        imdb_tsv.update_rating(g, self.ratings[0])
         expected = {
             "title": "Three Little Words",
             "adult": 0,
@@ -230,27 +75,29 @@ class TestIMDbTsv(TestCase):
 
     def test_add_contribution(self):
         g = self.make_graph()
-        expected = {"contributions": {"actor": {"ordering": 1, "job": "\\N"}}}
+        expected = {"ordering": 1, "contributions": {"actor": {"job": "\\N"}}}
         actual = g.edges[(PersonNode(1), WorkNode(43044))]
         self.assertEqual(expected, actual)
 
     def test_has_profession(self):
         g = self.make_graph()
-        self.assertFalse(imdb_tsv.hasProfession(g, PersonNode(8888888888), "actor"))
-        self.assertFalse(imdb_tsv.hasProfession(g, PersonNode(1), "producer"))
-        self.assertTrue(imdb_tsv.hasProfession(g, PersonNode(3), "producer"))
+        self.assertFalse(
+            imdb_tsv.has_profession_in_graph(g, PersonNode(8888888888), "actor")
+        )
+        self.assertFalse(imdb_tsv.has_profession_in_graph(g, PersonNode(1), "producer"))
+        self.assertTrue(imdb_tsv.has_profession_in_graph(g, PersonNode(3), "producer"))
 
     def test_is_actor(self):
         g = self.make_graph()
-        self.assertTrue(imdb_tsv.isActor(g, PersonNode(1)))
-        self.assertFalse(imdb_tsv.isActor(g, PersonNode(2)))
-        self.assertFalse(imdb_tsv.isActor(g, PersonNode(3)))
+        self.assertTrue(imdb_tsv.is_actor_in_graph(g, PersonNode(1)))
+        self.assertFalse(imdb_tsv.is_actor_in_graph(g, PersonNode(2)))
+        self.assertFalse(imdb_tsv.is_actor_in_graph(g, PersonNode(3)))
 
     def test_is_actress(self):
         g = self.make_graph()
-        self.assertFalse(imdb_tsv.isActress(g, PersonNode(1)))
-        self.assertTrue(imdb_tsv.isActress(g, PersonNode(2)))
-        self.assertTrue(imdb_tsv.isActress(g, PersonNode(3)))
+        self.assertFalse(imdb_tsv.is_actress_in_graph(g, PersonNode(1)))
+        self.assertTrue(imdb_tsv.is_actress_in_graph(g, PersonNode(2)))
+        self.assertTrue(imdb_tsv.is_actress_in_graph(g, PersonNode(3)))
 
     def test_contributed_as(self):
         g = self.make_graph()
@@ -259,9 +106,17 @@ class TestIMDbTsv(TestCase):
         the_mirror_has_two_faces = WorkNode(117057)
         self.assertIn(three_little_words, g.nodes)
         self.assertIn((thorpe, three_little_words), g.edges)
-        self.assertTrue(imdb_tsv.contributedAs(g, thorpe, three_little_words, 'director'))
-        self.assertFalse(imdb_tsv.contributedAs(g, thorpe, three_little_words, 'cook'))
-        self.assertFalse(imdb_tsv.contributedAs(g, thorpe, the_mirror_has_two_faces, 'director'))
+        self.assertTrue(
+            imdb_tsv.contributed_as_in_graph(g, thorpe, three_little_words, "director")
+        )
+        self.assertFalse(
+            imdb_tsv.contributed_as_in_graph(g, thorpe, three_little_words, "cook")
+        )
+        self.assertFalse(
+            imdb_tsv.contributed_as_in_graph(
+                g, thorpe, the_mirror_has_two_faces, "director"
+            )
+        )
 
     def test_acted_in(self):
         g = self.make_graph()
@@ -270,9 +125,42 @@ class TestIMDbTsv(TestCase):
         bacall = PersonNode(2)
         three_little_words = WorkNode(43044)
         the_mirror_has_two_faces = WorkNode(117057)
-        self.assertFalse(imdb_tsv.actedIn(g, thorpe, three_little_words))
-        self.assertFalse(imdb_tsv.actedIn(g, thorpe, the_mirror_has_two_faces))
-        self.assertTrue(imdb_tsv.actedIn(g, astaire, three_little_words))
-        self.assertFalse(imdb_tsv.actedIn(g, astaire, the_mirror_has_two_faces))
-        self.assertFalse(imdb_tsv.actedIn(g, bacall, three_little_words))
-        self.assertTrue(imdb_tsv.actedIn(g, bacall, the_mirror_has_two_faces))
+        self.assertFalse(imdb_tsv.acted_in_in_graph(g, thorpe, three_little_words))
+        self.assertFalse(
+            imdb_tsv.acted_in_in_graph(g, thorpe, the_mirror_has_two_faces)
+        )
+        self.assertTrue(imdb_tsv.acted_in_in_graph(g, astaire, three_little_words))
+        self.assertFalse(
+            imdb_tsv.acted_in_in_graph(g, astaire, the_mirror_has_two_faces)
+        )
+        self.assertFalse(imdb_tsv.acted_in_in_graph(g, bacall, three_little_words))
+        self.assertTrue(imdb_tsv.acted_in_in_graph(g, bacall, the_mirror_has_two_faces))
+
+    def test_votes(self):
+        g = self.make_graph()
+        three_little_words = g.nodes[WorkNode(43044)]
+        the_mirror_has_two_faces = g.nodes[WorkNode(117057)]
+        self.assertEqual(1497, imdb_tsv.get_votes(three_little_words))
+        self.assertEqual(14369, imdb_tsv.get_votes(the_mirror_has_two_faces))
+
+    def test_rating(self):
+        g = self.make_graph()
+        three_little_words = g.nodes[WorkNode(43044)]
+        the_mirror_has_two_faces = g.nodes[WorkNode(117057)]
+        self.assertEqual(6.9, imdb_tsv.get_rating(three_little_words))
+        self.assertEqual(6.6, imdb_tsv.get_rating(the_mirror_has_two_faces))
+
+    def test_order(self):
+        g = self.make_graph()
+
+        e = g.edges[(PersonNode(1), WorkNode(43044))]
+        self.assertEqual(1, imdb_tsv.get_order(e))
+
+        e = g.edges[(PersonNode(1), WorkNode(50419))]
+        self.assertEqual(2, imdb_tsv.get_order(e))
+
+        e = g.edges[(PersonNode(2), WorkNode(117057))]
+        self.assertEqual(3, imdb_tsv.get_order(e))
+
+        e = g.edges[(PersonNode(861703), WorkNode(43044))]
+        self.assertEqual(5, imdb_tsv.get_order(e))

--- a/cinema/tests/test_weights.py
+++ b/cinema/tests/test_weights.py
@@ -1,0 +1,136 @@
+from django.test import TestCase
+
+import math
+import networkx as nx
+
+from cinema.tests.fixture_imbd_tsv import FixtureIMDbTsv
+from cinema.cinegraph import weights
+from cinema.cinegraph import imdb_tsv
+from cinema.cinegraph.grapher import PersonNode, WorkNode
+
+
+class TestWeights(TestCase, FixtureIMDbTsv):
+    def setUp(self):
+        FixtureIMDbTsv.setUp(self)
+
+    def tearDown(self):
+        pass
+
+    def make_multi_weight_graph(self):
+        g = nx.cycle_graph(3)
+        g.edges[(0, 1)].update({"a": 0, "b": 1})
+        g.edges[(1, 2)].update({"a": 3, "b": 2})
+        g.edges[(2, 0)].update({"a": 1, "b": -1})
+        return g
+
+    def test_order_weight(self):
+        self.assertAlmostEqual(1, weights.credit_order_weight(1))
+        self.assertAlmostEqual(0.4172170546520899, weights.credit_order_weight(3))
+        self.assertAlmostEqual(0.12993833825732815, weights.credit_order_weight(5))
+        self.assertAlmostEqual(0.004945246313269536, weights.credit_order_weight(10))
+
+    def test_ratings_weight(self):
+        self.assertEqual(1, weights.rating_weight(10))
+        self.assertEqual(0.75, weights.rating_weight(7.5))
+        self.assertEqual(0.25, weights.rating_weight(2.5))
+
+    def test_normalized_activation(self):
+        self.assertAlmostEqual(0.01798620996209155, weights.normalized_activation(-2))
+        self.assertAlmostEqual(0.11920292202211757, weights.normalized_activation(-1))
+        self.assertAlmostEqual(0.5, weights.normalized_activation(0))
+        self.assertAlmostEqual(0.8807970779778824, weights.normalized_activation(1))
+        self.assertAlmostEqual(0.9820137900379085, weights.normalized_activation(2))
+
+    def test_mean_std(self):
+        g = self.make_graph()
+        mu, sigma = weights.node_mean_std(
+            g, imdb_tsv.get_votes, lambda n, _: not n.is_person
+        )
+        self.assertAlmostEqual(13005.75, mu)
+        self.assertAlmostEqual(8347.634017342878, sigma)
+
+    def test_votes_mean_std(self):
+        g = self.make_graph()
+        mu, sigma = weights.votes_mean_std(g)
+        self.assertAlmostEqual(13005.75, mu)
+        self.assertAlmostEqual(8347.634017342878, sigma)
+
+    def test_product_of_weights(self):
+        g = self.make_multi_weight_graph()
+        new_weight = weights.multiply_weights(g, "a", "b")
+        self.assertEqual("a_b", new_weight)
+        self.assertEqual(0, g.edges[(0, 1)]["a_b"])
+        self.assertEqual(6, g.edges[(1, 2)]["a_b"])
+        self.assertEqual(-1, g.edges[(2, 0)]["a_b"])
+
+    def test_sum_of_weights(self):
+        g = self.make_multi_weight_graph()
+        new_weight = weights.sum_weights(g, "a", "b")
+        self.assertEqual("a_b", new_weight)
+        self.assertEqual(1, g.edges[(0, 1)]["a_b"])
+        self.assertEqual(5, g.edges[(1, 2)]["a_b"])
+        self.assertEqual(0, g.edges[(2, 0)]["a_b"])
+
+    def test_normalize_votes_weights(self):
+        def activate(x):
+            y = (x - mu) / sigma
+            y = (math.tanh(y) + 1) / 2
+            return y
+
+        g = self.make_graph()
+        weight = "vote_weight"
+        mu, sigma = 13005.75, 8347.634017342878
+        weights.weight_by_normalized_votes(g, weight=weight)
+        self.assertAlmostEqual(
+            activate(1497), g.edges[(PersonNode(1), WorkNode(43044))][weight]
+        )
+        self.assertAlmostEqual(
+            activate(24896), g.edges[(PersonNode(1), WorkNode(50419))][weight]
+        )
+        self.assertAlmostEqual(
+            activate(14369), g.edges[(PersonNode(2), WorkNode(117057))][weight]
+        )
+        self.assertAlmostEqual(
+            activate(1497), g.edges[(PersonNode(861703), WorkNode(43044))][weight]
+        )
+
+    def test_actors_only_weights(self):
+        g = self.make_graph()
+        weight = "actor_weight"
+        weights.weight_only_actors(g, weight=weight)
+        self.assertEqual(1, g.edges[(PersonNode(1), WorkNode(43044))][weight])
+        self.assertEqual(1, g.edges[(PersonNode(1), WorkNode(50419))][weight])
+        self.assertEqual(1, g.edges[(PersonNode(2), WorkNode(117057))][weight])
+        self.assertEqual(0, g.edges[(PersonNode(861703), WorkNode(43044))][weight])
+
+    def test_credit_order_weights(self):
+        def activation(x):
+            y = (1 - x) / 3
+            return math.tanh(y) + 1
+
+        g = self.make_graph()
+        weight = "credit_weight"
+        weights.weight_credit_order(g, weight=weight)
+        self.assertEqual(
+            activation(1), g.edges[(PersonNode(1), WorkNode(43044))][weight]
+        )
+        self.assertEqual(
+            activation(2), g.edges[(PersonNode(1), WorkNode(50419))][weight]
+        )
+        self.assertEqual(
+            activation(3), g.edges[(PersonNode(2), WorkNode(117057))][weight]
+        )
+        self.assertEqual(
+            activation(5), g.edges[(PersonNode(861703), WorkNode(43044))][weight]
+        )
+
+    def test_rating_weights(self):
+        g = self.make_graph()
+        weight = "rating_weight"
+        weights.weight_by_rating(g, weight=weight)
+        self.assertAlmostEqual(0.69, g.edges[(PersonNode(1), WorkNode(43044))][weight])
+        self.assertAlmostEqual(0.70, g.edges[(PersonNode(1), WorkNode(50419))][weight])
+        self.assertAlmostEqual(0.66, g.edges[(PersonNode(2), WorkNode(117057))][weight])
+        self.assertAlmostEqual(
+            0.69, g.edges[(PersonNode(861703), WorkNode(43044))][weight]
+        )

--- a/cinema/tests/test_weights.py
+++ b/cinema/tests/test_weights.py
@@ -134,3 +134,15 @@ class TestWeights(TestCase, FixtureIMDbTsv):
         self.assertAlmostEqual(
             0.69, g.edges[(PersonNode(861703), WorkNode(43044))][weight]
         )
+
+    def test_missing_weights(self):
+        g = self.make_graph()
+        del g.nodes[WorkNode(43044)]["rating"]
+        weight = "rating_weight"
+        weights.weight_by_rating(g, weight=weight)
+        self.assertAlmostEqual(0, g.edges[(PersonNode(1), WorkNode(43044))][weight])
+        self.assertAlmostEqual(0.70, g.edges[(PersonNode(1), WorkNode(50419))][weight])
+        self.assertAlmostEqual(0.66, g.edges[(PersonNode(2), WorkNode(117057))][weight])
+        self.assertAlmostEqual(
+            0, g.edges[(PersonNode(861703), WorkNode(43044))][weight]
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ djangorestframework==3.11.0
 django-jsonfield==1.4.0
 django-extensions==3.1.0
 gensim==3.8.3
-
-
+tqdm==4.56.0
+requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy==1.18.1
+numpy>=1.18
+pandas>=1.2
 networkx==2.4
 IMDbPY==6.8
 Django==2.2.9


### PR DESCRIPTION
Previously building a professional graph required importing data into a SQL database using IMDbPY package. While are advantages to having access to this S3 data using SQL, some users have requested a way to access without a SQL database server running. This is now possible using the code in this PR.

There are some additional requirements in requirements.txt. After installing those requirements, it should be possible to download the data and create a pickled professional graph of movies, actors, actresses, writers, directors and producers from a command line script as explained in the updated README.md file.

For some preliminary results, see blog post
https://rb-and-lpx-foundation.org/?p=192