### PR TITLE
Generate paths of minimum length using only specific people nodes

### DIFF
--- a/cinema/cinegame/game.py
+++ b/cinema/cinegame/game.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import uuid
 
 from cinema.cinegraph.extractor import filmography_filter
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 from cinema.gameplay.models import Gameplay
 
 

--- a/cinema/cinegame/game_maker.py
+++ b/cinema/cinegame/game_maker.py
@@ -1,5 +1,56 @@
+from typing import Iterable
+
 import numpy as np
 import networkx as nx
+
+from cinema.cinegraph.node_types import ProfessionalNode, PersonNode, WorkNode
+
+
+class CandidateNotFoundException(Exception):
+    pass
+
+
+class GameNotFoundException(Exception):
+    pass
+
+
+def select_random_nodes(
+    nodes: Iterable[ProfessionalNode],
+    size=1,
+    replace: bool = False,
+    r: np.random.RandomState = None,
+):
+    nodes = list(nodes)
+    nodes.sort(key=repr)
+    return r.choice(nodes, size=size, replace=replace)
+
+
+def make_people_subgraph(g: nx.Graph, people: Iterable[PersonNode]):
+    people = set(people)
+    works = [node for node in g.nodes if not node.is_person and not people.isdisjoint(g.neighbors(node))]
+    nodes = people.union(works)
+    return g.subgraph(nodes)
+
+
+def make_game_from_starting_node(
+    g: nx.Graph, start, candidates, distance, r: np.random.RandomState = None
+):
+    candidates = set(candidates)
+    if r is None:
+        r = np.random.RandomState()
+
+    outer_ego_graph = nx.ego_graph(g, start, radius=2 * distance)
+    inner_ego_graph = nx.ego_graph(outer_ego_graph, start, radius=2 * distance - 1)
+
+    candidates.intersection_update(outer_ego_graph.nodes)
+    candidates.difference_update(inner_ego_graph.nodes)
+
+    if len(candidates) == 0:
+        raise CandidateNotFoundException()
+
+    end, = select_random_nodes(candidates, r=r)
+
+    return start, end
 
 
 def make_game_by_iteration(
@@ -8,15 +59,24 @@ def make_game_by_iteration(
     candidates = list(candidates)
     if r is None:
         r = np.random.RandomState()
-    a = r.choice(candidates)
-    b = a
-    d0 = 0
     for _ in range(max_iter):
-        c, d = r.choice(candidates, 2, replace=False)
-        d1 = nx.shortest_path_length(g, c, d)
-        if 2 * distance >= d1 > d0:
-            a, b = c, d
-            d0 = d1
-        if d0 == 2 * distance:
-            break
-    return a, b
+        try:
+            return make_game_from_starting_node(g, r.choice(candidates), candidates, distance, r)
+        except CandidateNotFoundException:
+            continue
+
+    raise GameNotFoundException()
+
+
+
+class GameMaker:
+    candidates: set[PersonNode]
+    g: nx.Graph
+
+    def __init__(self, g: nx.Graph, candidates: Iterable[PersonNode]):
+        self.g = make_people_subgraph(g, candidates)
+        self.candidates = set(candidates)
+
+    def make_game(self, distance, r: np.random.RandomState = None) -> tuple[PersonNode, PersonNode]:
+        return make_game_by_iteration(self.g, self.candidates, distance, r=r)
+

--- a/cinema/cinegraph/fame.py
+++ b/cinema/cinegraph/fame.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import numpy as np
 
-from cinema.cinegraph.grapher import PersonNode
+from cinema.cinegraph.node_types import PersonNode
 
 
 def get_people(g):

--- a/cinema/cinegraph/grapher.py
+++ b/cinema/cinegraph/grapher.py
@@ -1,5 +1,6 @@
 import networkx as nx
 
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 
 verbose = False
 
@@ -7,41 +8,6 @@ verbose = False
 def blurt(s):
     if verbose:
         print(s)
-
-
-class ProfessionalNode:
-    def __init__(self, id, is_person):
-        self.id = id
-        self.is_person = is_person
-
-    def __hash__(self):
-        return hash(self.id) + hash(self.is_person)
-
-    def __eq__(self, other):
-        return self.id == other.id and self.is_person == other.is_person
-
-    @property
-    def description_str(self):
-        return "person" if self.is_person else "work"
-
-    def __str__(self):
-        return "<{} {}>".format(self.description_str, self.id)
-
-
-class PersonNode(ProfessionalNode):
-    def __init__(self, id):
-        ProfessionalNode.__init__(self, id, True)
-
-    def __repr__(self):
-        return "PersonNode({})".format(self.id)
-
-
-class WorkNode(ProfessionalNode):
-    def __init__(self, id):
-        ProfessionalNode.__init__(self, id, False)
-
-    def __repr__(self):
-        return "WorkNode({})".format(self.id)
 
 
 def add_arc(g: nx.Graph, work, person, job=None):

--- a/cinema/cinegraph/imdb_tsv.py
+++ b/cinema/cinegraph/imdb_tsv.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from cinema import directories
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 
 
 class IMDbPersonNode(PersonNode):

--- a/cinema/cinegraph/node_types.py
+++ b/cinema/cinegraph/node_types.py
@@ -1,0 +1,39 @@
+class ProfessionalNode:
+    id: int | str
+    is_person: bool
+
+    def __init__(self, id: int | str, is_person: bool):
+        self.id = id
+        self.is_person = is_person
+
+    def __hash__(self):
+        return hash(self.id) + hash(self.is_person)
+
+    def __eq__(self, other):
+        return self.id == other.id and self.is_person == other.is_person
+
+    @property
+    def description_str(self):
+        return "person" if self.is_person else "work"
+
+    def __str__(self):
+        return "<{} {}>".format(self.description_str, self.id)
+
+    def __repr__(self):
+        return "ProfessionalNode({}, {})".format(repr(self.id), bool(self.is_person))
+
+
+class PersonNode(ProfessionalNode):
+    def __init__(self, id):
+        ProfessionalNode.__init__(self, id, True)
+
+    def __repr__(self):
+        return "PersonNode({})".format(repr(self.id))
+
+
+class WorkNode(ProfessionalNode):
+    def __init__(self, id):
+        ProfessionalNode.__init__(self, id, False)
+
+    def __repr__(self):
+        return "WorkNode({})".format(repr(self.id))

--- a/cinema/cinegraph/professional_path.py
+++ b/cinema/cinegraph/professional_path.py
@@ -4,7 +4,7 @@ import networkx as nx
 def professional_subgraph(g: nx.Graph, jobs):
     """
     Get edge subgraph containing where work nodes are connected only by collaborators with particular jobs.
-    For example, if the professional graph is one where words are movies and collaborators are actors, directors and
+    For example, if the professional graph is one where works are movies and collaborators are actors, directors and
     writers, this function can be used to find the subgraph connected by actors.
     :param g: professional bipartite graph
     :param jobs: those jobs we want in the subgraph

--- a/cinema/core/scripts/make_imdb_professional_graph.py
+++ b/cinema/core/scripts/make_imdb_professional_graph.py
@@ -11,7 +11,7 @@ import pickle
 
 from cinema import directories
 from cinema.cinegraph import imdb_tsv
-from cinema.cinegraph.grapher import PersonNode
+from cinema.cinegraph.node_types import PersonNode
 
 
 def retrieve_imdb_data(filename):

--- a/cinema/gameplay/tests.py
+++ b/cinema/gameplay/tests.py
@@ -1,17 +1,13 @@
-import uuid
-from datetime import datetime, date
+from datetime import datetime
 import imdb
-import pickle
 
-from .models import Gameplay
+from cinema.gameplay.models import Gameplay
 from cinema.cinegame.game import GameGraphAndHTTP
-from cinema.cinegraph.imdb_grapher import movie_actor_subgraph
 from django.test import TestCase
 from cinema.tests import data4tests
 
 
-# Create your tests here.
-class GameplayTestCase(TestCase):
+class TestGameplay(TestCase):
     def test_game_data_stored_properly(self):
 
         game_data = {

--- a/cinema/tests/data4tests.py
+++ b/cinema/tests/data4tests.py
@@ -1,7 +1,7 @@
 import pickle
 import numpy as np
 from cinema import directories
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 
 
 class MockImdbObject(dict):

--- a/cinema/tests/test_fame.py
+++ b/cinema/tests/test_fame.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 import numpy as np
 from numpy.linalg import norm
 
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 from cinema.tests import data4tests
 from cinema.cinegraph import fame
 

--- a/cinema/tests/test_game_maker.py
+++ b/cinema/tests/test_game_maker.py
@@ -3,9 +3,9 @@ from django.test import TestCase
 import numpy as np
 import networkx as nx
 
-from cinema.tests.data4tests import get_small_graph
-from cinema.cinegraph.grapher import PersonNode
-from cinema.cinegame import game_maker
+from .data4tests import get_small_graph
+from ..cinegame import game_maker
+from ..cinegraph.node_types import PersonNode
 
 
 class TestGameMaker(TestCase):
@@ -13,49 +13,170 @@ class TestGameMaker(TestCase):
         self.g = get_small_graph()
         self.r = np.random.RandomState(42)
 
+        # select one third of the actors in the graph as candidates for start and end nodes
+        self.candidates = [
+            node for node in self.g.nodes if node.is_person and (node.id % 3 == 0)
+        ]
+
     def tearDown(self):
         pass
 
+    def test_select_random_nodes(self):
+        nodes = [PersonNode(0), PersonNode(1), PersonNode("asdf"), PersonNode("42"), PersonNode(42)]
+        r = np.random.RandomState(42)
+
+        a, = game_maker.select_random_nodes(nodes, r=r)
+        self.assertEqual(PersonNode("asdf"), a)
+
+        a, = game_maker.select_random_nodes(nodes, r=r)
+        self.assertEqual(PersonNode(1), a)
+
+        a, = game_maker.select_random_nodes(nodes, r=r)
+        self.assertEqual(PersonNode("asdf"), a)
+
+        a, b = game_maker.select_random_nodes(nodes, size=2, r=r)
+        self.assertEqual(PersonNode("42"), a)
+        self.assertEqual(PersonNode("asdf"), b)
+
+        a, b = game_maker.select_random_nodes(nodes, size=2, r=r)
+        self.assertEqual(PersonNode("42"), a)
+        self.assertEqual(PersonNode(0), b)
+
+        r0 = np.random.RandomState(42)
+        r1 = np.random.RandomState(42)
+
+        # selection should be repeatable of order of nodes
+        for _ in range(100):
+            a, b = game_maker.select_random_nodes(nodes, size=2, r=r0)
+            c, d = game_maker.select_random_nodes(nodes, size=2, r=r1)
+            self.assertEqual(a, c)
+            self.assertEqual(b, d)
+
+        shuffled_nodes = nodes.copy()
+        r.shuffle(shuffled_nodes)
+
+        # selection should be independent of order of nodes
+        for _ in range(100):
+            a, b = game_maker.select_random_nodes(nodes, size=2, r=r0)
+            c, d = game_maker.select_random_nodes(shuffled_nodes, size=2, r=r1)
+            self.assertEqual(a, c)
+            self.assertEqual(b, d)
+
+        # selection should be independent of type of iterable
+        for _ in range(100):
+            a, b = game_maker.select_random_nodes(nodes, size=2, r=r0)
+            c, d = game_maker.select_random_nodes(set(nodes), size=2, r=r1)
+            self.assertEqual(a, c)
+            self.assertEqual(b, d)
+
+    def test_make_people_subgraph(self):
+        people_subgraph = game_maker.make_people_subgraph(self.g, self.candidates)
+
+        candidates = set(self.candidates)
+
+        all_subgraph_nodes = set(people_subgraph.nodes)
+        self.assertTrue(candidates.issubset(all_subgraph_nodes))
+
+        for node in people_subgraph.nodes:
+            if node.is_person:
+                self.assertTrue(node in candidates)
+            else:
+                self.assertTrue(people_subgraph.degree(node) > 0)
+
+    def test_make_game_from_starting_node_fail(self):
+        # there is no game of length five starting from the first candidate
+        with self.assertRaises(game_maker.CandidateNotFoundException):
+            game_maker.make_game_from_starting_node(self.g, self.candidates[0], self.candidates, 5, r=self.r)
+
+    def test_make_game_from_starting_node(self):
+        candidates = self.candidates
+        # find games of length 1
+        a, b = game_maker.make_game_from_starting_node(self.g, candidates[0], candidates, 1, r=self.r)
+        self.assertEqual(candidates[0], a)
+        self.assertEqual(2, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(PersonNode(92184), a)
+        self.assertEqual(PersonNode(2091), b)
+
+        a, b = game_maker.make_game_from_starting_node(self.g, candidates[2], candidates, 1, r=self.r)
+        self.assertEqual(candidates[2], a)
+        self.assertEqual(2, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(PersonNode(345), a)
+        self.assertEqual(PersonNode(114), b)
+
+        # find game of length 2
+        a, b = game_maker.make_game_from_starting_node(self.g, candidates[2], candidates, 2, r=self.r)
+        self.assertEqual(candidates[2], a)
+        self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(PersonNode(345), a)
+        self.assertEqual(PersonNode(246), b)
+
+        # find game of length 4
+        a, b = game_maker.make_game_from_starting_node(self.g, candidates[2], candidates, 4, r=self.r)
+        self.assertEqual(candidates[2], a)
+        self.assertEqual(8, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(PersonNode(345), a)
+        self.assertEqual(PersonNode(4851), b)
+
+    def test_make_game_by_iteration_fail(self):
+        # there is no game of length five
+        with self.assertRaises(game_maker.GameNotFoundException):
+            game_maker.make_game_by_iteration(self.g, self.candidates, 5, r=self.r, max_iter=10)
+
     def test_make_game_by_iteration(self):
-        pass
-        # TODO: Something is wrong
-        # select one third of the actors in the graph as candidates for start and end nodes
-        # candidates = [node for node in self.g.nodes if node.is_person and (node.id % 3 == 0)]
-        #
-        # # choose actors who have been in the same movie
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 1, r=self.r)
-        # self.assertEqual(PersonNode(51), a)
-        # self.assertEqual(PersonNode(532290), b)
-        # self.assertEqual(2, nx.shortest_path_length(self.g, a, b))
-        #
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 1, r=self.r)
-        # self.assertEqual(PersonNode(1512), a)
-        # self.assertEqual(PersonNode(147), b)
-        # self.assertEqual(2, nx.shortest_path_length(self.g, a, b))
-        #
-        # # choose actors who are two movies apart
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 2, r=self.r)
-        # self.assertEqual(PersonNode(171513), a)
-        # self.assertEqual(PersonNode(1644), b)
-        # self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
-        #
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 2, r=self.r)
-        # self.assertEqual(PersonNode(378), a)
-        # self.assertEqual(PersonNode(1512), b)
-        # self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
-        #
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 2, r=self.r)
-        # self.assertEqual(PersonNode(770961), a)
-        # self.assertEqual(PersonNode(138), b)
-        # self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
-        #
-        # # choose some actors that are three movies apart
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 3, r=self.r)
-        # self.assertEqual(PersonNode(330687), a)
-        # self.assertEqual(PersonNode(1605114), b)
-        # self.assertEqual(6, nx.shortest_path_length(self.g, a, b))
-        #
-        # a, b = game_maker.make_game_by_iteration(self.g, candidates, 3, r=self.r)
-        # self.assertEqual(PersonNode(123), a)
-        # self.assertEqual(PersonNode(861915), b)
-        # self.assertEqual(6, nx.shortest_path_length(self.g, a, b))
+        candidates = self.candidates
+
+        # choose actors who have been in the same movie
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 1, r=self.r)
+        first_choice = a.id
+        self.assertEqual(2, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(a, PersonNode(7955301))
+        self.assertEqual(b, PersonNode(147))
+
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 1, r=self.r)
+        self.assertNotEquals(first_choice, a.id)
+        self.assertEqual(2, nx.shortest_path_length(self.g, a, b))
+
+        # choose actors who are two movies apart
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 2, r=self.r)
+        self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(PersonNode(111), a)
+        self.assertEqual(PersonNode(309693), b)
+
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 2, r=self.r)
+        self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
+
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 2, r=self.r)
+        self.assertEqual(4, nx.shortest_path_length(self.g, a, b))
+
+        # choose some actors that are three movies apart
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 3, r=self.r)
+        self.assertEqual(6, nx.shortest_path_length(self.g, a, b))
+
+        a, b = game_maker.make_game_by_iteration(self.g, candidates, 3, r=self.r)
+        self.assertEqual(6, nx.shortest_path_length(self.g, a, b))
+        self.assertEqual(PersonNode(1605114), a)
+        self.assertEqual(PersonNode(261), b)
+
+
+    def test_game_maker(self):
+        gm = game_maker.GameMaker(self.g, self.candidates)
+        self.assertEqual(set(self.candidates), gm.candidates)
+
+        # find games of length 1
+        a, b = gm.make_game(1, r=self.r)
+        self.assertEqual(2, nx.shortest_path_length(gm.g, a, b))
+        self.assertEqual(PersonNode(228), a)
+        self.assertEqual(PersonNode(396558), b)
+
+        a, b = gm.make_game(2, r=self.r)
+        self.assertEqual(4, nx.shortest_path_length(gm.g, a, b))
+        self.assertEqual(PersonNode(168), a)
+        self.assertEqual(PersonNode(102), b)
+
+        a, b = gm.make_game(4, r=self.r)
+        self.assertEqual(8, nx.shortest_path_length(gm.g, a, b))
+        self.assertEqual(PersonNode(744834), a)
+        self.assertEqual(PersonNode(7955301), b)
+
+        with self.assertRaises(game_maker.GameNotFoundException):
+            gm.make_game(10, r=self.r)

--- a/cinema/tests/test_grapher.py
+++ b/cinema/tests/test_grapher.py
@@ -1,6 +1,6 @@
 import networkx as nx
 from cinema.cinegraph import grapher
-from cinema.cinegraph.grapher import ProfessionalNode, PersonNode, WorkNode
+from cinema.cinegraph.node_types import ProfessionalNode, PersonNode, WorkNode
 
 from django.test import TestCase
 
@@ -11,37 +11,6 @@ class TestGrapher(TestCase):
 
     def tearDown(self):
         pass
-
-    def test_professional_node(self):
-        n0 = ProfessionalNode(42, False)
-        n1 = ProfessionalNode(42, False)
-        n2 = ProfessionalNode(41, False)
-        n3 = ProfessionalNode(42, True)
-
-        self.assertEqual(n0, n1)
-        self.assertEqual(hash(n0), hash(n1))
-
-        self.assertNotEqual(n0, n2)
-        self.assertNotEqual(hash(n0), hash(n2))
-
-        self.assertNotEqual(n0, n3)
-        self.assertNotEqual(hash(n0), hash(n3))
-
-    def test_person_node(self):
-        n0 = ProfessionalNode(42, True)
-        n1 = PersonNode(42)
-
-        self.assertTrue(n1.is_person)
-        self.assertEqual(n0, n1)
-        self.assertEqual(hash(n0), hash(n1))
-
-    def test_movie_node(self):
-        n0 = ProfessionalNode(42, False)
-        n1 = WorkNode(42)
-
-        self.assertFalse(n1.is_person)
-        self.assertEqual(n0, n1)
-        self.assertEqual(hash(n0), hash(n1))
 
     def test_add_arc(self):
         g = nx.Graph()

--- a/cinema/tests/test_imdb_tsv.py
+++ b/cinema/tests/test_imdb_tsv.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 import networkx as nx
 
 from cinema.tests.fixture_imbd_tsv import FixtureIMDbTsv
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 from cinema.cinegraph import imdb_tsv
 
 

--- a/cinema/tests/test_mock_imbd.py
+++ b/cinema/tests/test_mock_imbd.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 import numpy as np
 from numpy.linalg import norm
 
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 from cinema.tests import data4tests
 
 

--- a/cinema/tests/test_node_types.py
+++ b/cinema/tests/test_node_types.py
@@ -1,0 +1,73 @@
+from cinema.cinegraph.node_types import ProfessionalNode, PersonNode, WorkNode
+
+from django.test import TestCase
+
+
+class TestNodeTypes(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_professional_node(self):
+        n0 = ProfessionalNode(42, False)
+        s0 = ProfessionalNode("42", False)
+        n1 = ProfessionalNode(42, False)
+        n2 = ProfessionalNode(41, False)
+        n3 = ProfessionalNode(42, True)
+
+        self.assertEqual(n0, n1)
+        self.assertEqual(hash(n0), hash(n1))
+
+        self.assertNotEqual(n0, n2)
+        self.assertNotEqual(hash(n0), hash(n2))
+
+        self.assertNotEqual(n0, n3)
+        self.assertNotEqual(hash(n0), hash(n3))
+
+        self.assertNotEqual(n0, s0)
+        self.assertNotEqual(hash(n0), hash(s0))
+
+    def test_person_node(self):
+        n0 = ProfessionalNode(42, True)
+        n1 = PersonNode(42)
+
+        self.assertTrue(n1.is_person)
+        self.assertEqual(n0, n1)
+        self.assertEqual(hash(n0), hash(n1))
+
+    def test_movie_node(self):
+        n0 = ProfessionalNode(42, False)
+        n1 = WorkNode(42)
+
+        self.assertFalse(n1.is_person)
+        self.assertEqual(n0, n1)
+        self.assertEqual(hash(n0), hash(n1))
+
+    def test_node_to_string(self):
+        n0 = ProfessionalNode(0, False)
+        n1 = ProfessionalNode(1, True)
+
+        self.assertEqual("<work 0>", str(n0))
+        self.assertEqual("<person 1>", str(n1))
+
+    def test_node_repr(self):
+        n0 = ProfessionalNode(0, False)
+        n1 = ProfessionalNode(1, True)
+        w = WorkNode(2)
+        p = PersonNode(3)
+
+        self.assertEqual("ProfessionalNode(0, False)", repr(n0))
+        self.assertEqual("ProfessionalNode(1, True)", repr(n1))
+        self.assertEqual("WorkNode(2)", repr(w))
+        self.assertEqual("PersonNode(3)", repr(p))
+
+        s0 = ProfessionalNode("0", False)
+        sw = WorkNode("2")
+        sp = PersonNode("3")
+        self.assertEqual("ProfessionalNode('0', False)", repr(s0))
+        self.assertEqual("WorkNode('2')", repr(sw))
+        self.assertEqual("PersonNode('3')", repr(sp))
+
+

--- a/cinema/tests/test_professional_path.py
+++ b/cinema/tests/test_professional_path.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+
+
+class TestProfessionalPath(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    # def test_foo(self):
+    #     self.fail("incomplete")

--- a/cinema/tests/test_weights.py
+++ b/cinema/tests/test_weights.py
@@ -6,7 +6,7 @@ import networkx as nx
 from cinema.tests.fixture_imbd_tsv import FixtureIMDbTsv
 from cinema.cinegraph import weights
 from cinema.cinegraph import imdb_tsv
-from cinema.cinegraph.grapher import PersonNode, WorkNode
+from cinema.cinegraph.node_types import PersonNode, WorkNode
 
 
 class TestWeights(TestCase, FixtureIMDbTsv):

--- a/poetry.lock
+++ b/poetry.lock
@@ -687,6 +687,32 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.4.1"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.4.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2d9ef6231e3fbdc0b8c72404a1a0c46fd0dcea84efca83beb4681c318ea6a953"},
+    {file = "ruff-0.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9485f54a7189e6f7433e0058cf8581bee45c31a25cd69009d2a040d1bd4bfaef"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2921ac03ce1383e360e8a95442ffb0d757a6a7ddd9a5be68561a671e0e5807e"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eec8d185fe193ad053eda3a6be23069e0c8ba8c5d20bc5ace6e3b9e37d246d3f"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:baa27d9d72a94574d250f42b7640b3bd2edc4c58ac8ac2778a8c82374bb27984"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f1ee41580bff1a651339eb3337c20c12f4037f6110a36ae4a2d864c52e5ef954"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0926cefb57fc5fced629603fbd1a23d458b25418681d96823992ba975f050c2b"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c6e37f2e3cd74496a74af9a4fa67b547ab3ca137688c484749189bf3a686ceb"},
+    {file = "ruff-0.4.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efd703a5975ac1998c2cc5e9494e13b28f31e66c616b0a76e206de2562e0843c"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b92f03b4aa9fa23e1799b40f15f8b95cdc418782a567d6c43def65e1bbb7f1cf"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1c859f294f8633889e7d77de228b203eb0e9a03071b72b5989d89a0cf98ee262"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b34510141e393519a47f2d7b8216fec747ea1f2c81e85f076e9f2910588d4b64"},
+    {file = "ruff-0.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6e68d248ed688b9d69fd4d18737edcbb79c98b251bba5a2b031ce2470224bdf9"},
+    {file = "ruff-0.4.1-py3-none-win32.whl", hash = "sha256:b90506f3d6d1f41f43f9b7b5ff845aeefabed6d2494307bc7b178360a8805252"},
+    {file = "ruff-0.4.1-py3-none-win_amd64.whl", hash = "sha256:c7d391e5936af5c9e252743d767c564670dc3889aff460d35c518ee76e4b26d7"},
+    {file = "ruff-0.4.1-py3-none-win_arm64.whl", hash = "sha256:a1eaf03d87e6a7cd5e661d36d8c6e874693cb9bc3049d110bc9a97b350680c43"},
+    {file = "ruff-0.4.1.tar.gz", hash = "sha256:d592116cdbb65f8b1b7e2a2b48297eb865f6bdc20641879aa9d7b9c11d86db79"},
+]
+
+[[package]]
 name = "scipy"
 version = "1.12.0"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -1019,4 +1045,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "f70931676438ecb9a736bb4af5d1c3d1282948617d55835459032db83fb4d134"
+content-hash = "a0d092a8eeac8c2591cce7e18f77978bf77fd68a6e3e61ff13d7236ec7ab315b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ gensim = "^4.3"
 tqdm = "^4.56"
 requests = "^2.31"
 black = "^24.2.0"
+ruff = "^0.4.1"
 
 
 [build-system]


### PR DESCRIPTION
This should fix previous problems with the game generator. Now game maker class should find paths which only have people nodes from a set of candidates. This means that we can ensure that there exists a path which only includes famous actors, for example.

Also added several tests, and refactored some other files for sake of convenience.