### PR TITLE
Test backend

### DIFF
--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -1,6 +1,9 @@
 """
 Agentic loop base: runs Claude with tool use until it reaches a final answer.
 Handles both custom TMDb tools and Claude's built-in web_search tool.
+
+TODO: Abstract the LLM provider behind a testable interface (e.g. langchain)
+so we can substitute other providers or run locally with Ollama.
 """
 
 import json

--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -35,7 +35,9 @@ async def execute_tool(name: str, tool_input: dict) -> str:
     return json.dumps({"error": f"Unknown tool: {name}"})
 
 
-async def run_agent(system: str, user_message: str, tools: list, max_iterations: int = 10) -> str:
+async def run_agent(
+    system: str, user_message: str, tools: list, max_iterations: int = 10
+) -> str:
     """
     Async agentic loop. Runs Claude with tools until stop_reason == 'end_turn'.
     Returns the final text response from the model.
@@ -71,11 +73,13 @@ async def run_agent(system: str, user_message: str, tools: list, max_iterations:
                 if block.name == "web_search":
                     continue
                 result = await execute_tool(block.name, block.input)
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result,
-                })
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result,
+                    }
+                )
 
             if tool_results:
                 messages.append({"role": "user", "content": tool_results})

--- a/backend/agents/puzzle_agent.py
+++ b/backend/agents/puzzle_agent.py
@@ -35,12 +35,14 @@ async def _random_walk(
 
     When no_repeat_movies=True, the same movie cannot appear twice in the path.
     """
-    path = [{
-        "type": "actor",
-        "name": start_actor["name"],
-        "id": start_actor["id"],
-        "profile_url": start_actor.get("profile_url"),
-    }]
+    path = [
+        {
+            "type": "actor",
+            "name": start_actor["name"],
+            "id": start_actor["id"],
+            "profile_url": start_actor.get("profile_url"),
+        }
+    ]
     current_actor_id = start_actor["id"]
     used_movie_ids: set[int] = set()
 
@@ -59,14 +61,16 @@ async def _random_walk(
         movie = random.choice(movies[:10])
         used_movie_ids.add(movie["id"])
 
-        path.append({
-            "type": "movie",
-            "title": movie["title"],
-            "id": movie["id"],
-            "year": movie.get("year"),
-            "poster_url": movie.get("poster_url"),
-            "backdrop_url": movie.get("backdrop_url"),
-        })
+        path.append(
+            {
+                "type": "movie",
+                "title": movie["title"],
+                "id": movie["id"],
+                "year": movie.get("year"),
+                "poster_url": movie.get("poster_url"),
+                "backdrop_url": movie.get("backdrop_url"),
+            }
+        )
 
         # Get cast, excluding current actor
         cast = await tmdb.get_movie_cast(movie["id"])
@@ -74,7 +78,7 @@ async def _random_walk(
         if not cast:
             return None
 
-        is_last_hop = (hop == hops - 1)
+        is_last_hop = hop == hops - 1
         if is_last_hop:
             # Prefer end actor above the popularity floor; fall back to most popular available.
             scored = []
@@ -96,12 +100,14 @@ async def _random_walk(
             # Intermediate hops: top billing is a good popularity proxy
             next_actor = random.choice(cast[:15])
 
-        path.append({
-            "type": "actor",
-            "name": next_actor["name"],
-            "id": next_actor["id"],
-            "profile_url": next_actor.get("profile_url"),
-        })
+        path.append(
+            {
+                "type": "actor",
+                "name": next_actor["name"],
+                "id": next_actor["id"],
+                "profile_url": next_actor.get("profile_url"),
+            }
+        )
         current_actor_id = next_actor["id"]
 
     return path
@@ -120,22 +126,34 @@ async def generate_puzzle(difficulty: str = "medium") -> dict:
     hop_range = DIFFICULTY_HOPS.get(difficulty, (3, 5))
     hops = random.randint(*hop_range)
     min_pop = MIN_ACTOR_POPULARITY.get(difficulty, 4)
-    no_repeat = (difficulty == "easy")
+    no_repeat = difficulty == "easy"
 
     for _ in range(10):
         start_actor = await _pick_popular_actor(min_pop)
-        path = await _random_walk(start_actor, hops, min_pop, no_repeat_movies=no_repeat)
+        path = await _random_walk(
+            start_actor, hops, min_pop, no_repeat_movies=no_repeat
+        )
         if path and len(path) >= 3:
             break
     else:
-        raise RuntimeError(f"Failed to generate a valid {difficulty} puzzle after 10 attempts.")
+        raise RuntimeError(
+            f"Failed to generate a valid {difficulty} puzzle after 10 attempts."
+        )
 
     start = path[0]
     end = path[-1]
 
     return {
-        "start_actor": {"name": start["name"], "id": start["id"], "profile_url": start.get("profile_url")},
-        "end_actor": {"name": end["name"], "id": end["id"], "profile_url": end.get("profile_url")},
+        "start_actor": {
+            "name": start["name"],
+            "id": start["id"],
+            "profile_url": start.get("profile_url"),
+        },
+        "end_actor": {
+            "name": end["name"],
+            "id": end["id"],
+            "profile_url": end.get("profile_url"),
+        },
         "difficulty": difficulty,
         "min_moves": hops,
         "known_solution": path,

--- a/backend/agents/validation_agent.py
+++ b/backend/agents/validation_agent.py
@@ -1,6 +1,9 @@
 """
 Validation Agent: verifies that two actors both appeared in a named movie.
 Uses Claude with TMDb tools + web search to handle name variations and ambiguity.
+
+TODO: Abstract the LLM provider behind a testable interface (e.g. langchain)
+so we can substitute other providers or run locally with Ollama.
 """
 
 import json

--- a/backend/database.py
+++ b/backend/database.py
@@ -11,7 +11,8 @@ def get_db() -> sqlite3.Connection:
 
 def init_db():
     conn = get_db()
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS games (
             id TEXT PRIMARY KEY,
             start_actor_name TEXT NOT NULL,
@@ -27,33 +28,37 @@ def init_db():
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
-    """)
+    """
+    )
     conn.commit()
     conn.close()
 
 
 def save_game(game: dict):
     conn = get_db()
-    conn.execute("""
+    conn.execute(
+        """
         INSERT INTO games (
             id, start_actor_name, start_actor_id,
             end_actor_name, end_actor_id, difficulty,
             known_solution, moves, current_actor_name,
             current_actor_id, status
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    """, (
-        game["id"],
-        game["start_actor"]["name"],
-        game["start_actor"]["id"],
-        game["end_actor"]["name"],
-        game["end_actor"]["id"],
-        game["difficulty"],
-        json.dumps(game["known_solution"]),
-        json.dumps(game["moves"]),
-        game["current_actor"]["name"],
-        game["current_actor"]["id"],
-        game["status"],
-    ))
+    """,
+        (
+            game["id"],
+            game["start_actor"]["name"],
+            game["start_actor"]["id"],
+            game["end_actor"]["name"],
+            game["end_actor"]["id"],
+            game["difficulty"],
+            json.dumps(game["known_solution"]),
+            json.dumps(game["moves"]),
+            game["current_actor"]["name"],
+            game["current_actor"]["id"],
+            game["status"],
+        ),
+    )
     conn.commit()
     conn.close()
 
@@ -69,18 +74,21 @@ def load_game(game_id: str) -> dict | None:
 
 def update_game(game_id: str, moves: list, current_actor: dict, status: str):
     conn = get_db()
-    conn.execute("""
+    conn.execute(
+        """
         UPDATE games
         SET moves = ?, current_actor_name = ?, current_actor_id = ?,
             status = ?, updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
-    """, (
-        json.dumps(moves),
-        current_actor["name"],
-        current_actor["id"],
-        status,
-        game_id,
-    ))
+    """,
+        (
+            json.dumps(moves),
+            current_actor["name"],
+            current_actor["id"],
+            status,
+            game_id,
+        ),
+    )
     conn.commit()
     conn.close()
 
@@ -93,7 +101,10 @@ def _row_to_game(row: sqlite3.Row) -> dict:
         "difficulty": row["difficulty"],
         "known_solution": json.loads(row["known_solution"]),
         "moves": json.loads(row["moves"]),
-        "current_actor": {"name": row["current_actor_name"], "id": row["current_actor_id"]},
+        "current_actor": {
+            "name": row["current_actor_name"],
+            "id": row["current_actor_id"],
+        },
         "status": row["status"],
         "created_at": row["created_at"],
     }

--- a/backend/routes/game.py
+++ b/backend/routes/game.py
@@ -1,6 +1,13 @@
 import uuid
 from fastapi import APIRouter, HTTPException
-from models.game import NewGameResponse, MoveRequest, MoveResponse, GameState, Actor, Move
+from models.game import (
+    NewGameResponse,
+    MoveRequest,
+    MoveResponse,
+    GameState,
+    Actor,
+    Move,
+)
 from agents.puzzle_agent import generate_puzzle
 from agents.validation_agent import validate_move
 from tools.tmdb import tmdb
@@ -13,7 +20,11 @@ async def _resolve_actor(name: str, fallback_id: int = 0) -> dict:
     """Look up an actor by name and return their TMDb ID + canonical name."""
     person = await tmdb.search_person(name)
     if person:
-        return {"name": person["name"], "id": person["id"], "profile_url": person.get("profile_url")}
+        return {
+            "name": person["name"],
+            "id": person["id"],
+            "profile_url": person.get("profile_url"),
+        }
     return {"name": name, "id": fallback_id, "profile_url": None}
 
 
@@ -32,7 +43,9 @@ def _reached_end(next_actor_id: int, next_actor_name: str, end_actor: dict) -> b
 @router.post("/new", response_model=NewGameResponse)
 async def new_game(difficulty: str = "medium"):
     if difficulty not in ("easy", "medium", "hard"):
-        raise HTTPException(status_code=400, detail="difficulty must be easy, medium, or hard")
+        raise HTTPException(
+            status_code=400, detail="difficulty must be easy, medium, or hard"
+        )
 
     puzzle = await generate_puzzle(difficulty)
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,32 @@
+from config import DIFFICULTY_HOPS, MIN_ACTOR_POPULARITY
+
+
+class TestDifficultyHops:
+    def test_all_levels_present(self):
+        assert set(DIFFICULTY_HOPS.keys()) == {"easy", "medium", "hard"}
+
+    def test_values_are_tuples_of_two_ints(self):
+        for level, (lo, hi) in DIFFICULTY_HOPS.items():
+            assert isinstance(lo, int), f"{level} low bound is not int"
+            assert isinstance(hi, int), f"{level} high bound is not int"
+
+    def test_low_bound_le_high_bound(self):
+        for level, (lo, hi) in DIFFICULTY_HOPS.items():
+            assert lo <= hi, f"{level}: {lo} > {hi}"
+
+    def test_difficulty_ordering(self):
+        assert DIFFICULTY_HOPS["easy"][1] < DIFFICULTY_HOPS["medium"][1]
+        assert DIFFICULTY_HOPS["medium"][1] < DIFFICULTY_HOPS["hard"][1]
+
+
+class TestMinActorPopularity:
+    def test_all_levels_present(self):
+        assert set(MIN_ACTOR_POPULARITY.keys()) == {"easy", "medium", "hard"}
+
+    def test_values_are_positive(self):
+        for level, pop in MIN_ACTOR_POPULARITY.items():
+            assert pop > 0, f"{level} popularity is not positive"
+
+    def test_easy_has_highest_floor(self):
+        assert MIN_ACTOR_POPULARITY["easy"] > MIN_ACTOR_POPULARITY["medium"]
+        assert MIN_ACTOR_POPULARITY["medium"] > MIN_ACTOR_POPULARITY["hard"]

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -53,6 +53,7 @@ def use_in_memory_db():
 class TestInitDb:
     def test_creates_games_table(self):
         from database import get_db
+
         conn = get_db()
         cursor = conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='games'"
@@ -100,7 +101,13 @@ class TestUpdateGame:
         game = _make_game()
         save_game(game)
 
-        new_moves = [{"from_actor": "Brad Pitt", "movie": "12 Years a Slave", "to_actor": "Michael Fassbender"}]
+        new_moves = [
+            {
+                "from_actor": "Brad Pitt",
+                "movie": "12 Years a Slave",
+                "to_actor": "Michael Fassbender",
+            }
+        ]
         new_actor = {"name": "Michael Fassbender", "id": 17288}
         update_game("test-123", new_moves, new_actor, "in_progress")
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,131 @@
+import sqlite3
+import pytest
+from unittest.mock import patch
+from database import init_db, save_game, load_game, update_game
+
+
+def _make_game(game_id="test-123"):
+    return {
+        "id": game_id,
+        "start_actor": {"name": "Brad Pitt", "id": 287},
+        "end_actor": {"name": "Colin Firth", "id": 1891},
+        "difficulty": "medium",
+        "known_solution": [
+            {"type": "actor", "name": "Brad Pitt", "id": 287},
+            {"type": "movie", "title": "12 Years a Slave", "id": 76203},
+            {"type": "actor", "name": "Michael Fassbender", "id": 17288},
+        ],
+        "moves": [],
+        "current_actor": {"name": "Brad Pitt", "id": 287},
+        "status": "in_progress",
+    }
+
+
+class _NoCloseConnection:
+    """Wraps a sqlite3.Connection so that .close() is a no-op."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def close(self):
+        pass  # prevent database.py from closing the shared connection
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+@pytest.fixture(autouse=True)
+def use_in_memory_db():
+    """Use a shared named in-memory SQLite DB for each test."""
+    conn = sqlite3.connect("file::memory:?cache=shared", uri=True)
+    conn.row_factory = sqlite3.Row
+
+    def make_wrapper():
+        wrapper = _NoCloseConnection(conn)
+        return wrapper
+
+    with patch("database.get_db", side_effect=make_wrapper):
+        init_db()
+        yield
+    conn.close()
+
+
+class TestInitDb:
+    def test_creates_games_table(self):
+        from database import get_db
+        conn = get_db()
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='games'"
+        )
+        assert cursor.fetchone() is not None
+
+    def test_idempotent(self):
+        """Calling init_db twice doesn't raise."""
+        init_db()
+
+
+class TestSaveAndLoadGame:
+    def test_save_and_load(self):
+        game = _make_game()
+        save_game(game)
+        loaded = load_game("test-123")
+        assert loaded is not None
+        assert loaded["id"] == "test-123"
+        assert loaded["start_actor"] == {"name": "Brad Pitt", "id": 287}
+        assert loaded["end_actor"] == {"name": "Colin Firth", "id": 1891}
+        assert loaded["difficulty"] == "medium"
+        assert loaded["status"] == "in_progress"
+        assert loaded["moves"] == []
+        assert len(loaded["known_solution"]) == 3
+
+    def test_load_nonexistent(self):
+        assert load_game("does-not-exist") is None
+
+    def test_known_solution_round_trips_as_list(self):
+        game = _make_game()
+        save_game(game)
+        loaded = load_game("test-123")
+        assert isinstance(loaded["known_solution"], list)
+        assert loaded["known_solution"][1]["title"] == "12 Years a Slave"
+
+    def test_created_at_populated(self):
+        game = _make_game()
+        save_game(game)
+        loaded = load_game("test-123")
+        assert loaded["created_at"] is not None
+
+
+class TestUpdateGame:
+    def test_update_moves_and_status(self):
+        game = _make_game()
+        save_game(game)
+
+        new_moves = [{"from_actor": "Brad Pitt", "movie": "12 Years a Slave", "to_actor": "Michael Fassbender"}]
+        new_actor = {"name": "Michael Fassbender", "id": 17288}
+        update_game("test-123", new_moves, new_actor, "in_progress")
+
+        loaded = load_game("test-123")
+        assert loaded["moves"] == new_moves
+        assert loaded["current_actor"] == new_actor
+        assert loaded["status"] == "in_progress"
+
+    def test_update_to_won(self):
+        game = _make_game()
+        save_game(game)
+
+        update_game("test-123", [], {"name": "Colin Firth", "id": 1891}, "won")
+
+        loaded = load_game("test-123")
+        assert loaded["status"] == "won"
+        assert loaded["current_actor"]["name"] == "Colin Firth"
+
+    def test_multiple_games_independent(self):
+        save_game(_make_game("game-a"))
+        save_game(_make_game("game-b"))
+
+        update_game("game-a", [{"move": 1}], {"name": "X", "id": 1}, "won")
+
+        a = load_game("game-a")
+        b = load_game("game-b")
+        assert a["status"] == "won"
+        assert b["status"] == "in_progress"

--- a/backend/tests/test_definitions.py
+++ b/backend/tests/test_definitions.py
@@ -1,0 +1,44 @@
+from tools.definitions import TMDB_TOOLS, WEB_SEARCH_TOOL, ALL_TOOLS
+
+
+class TestTmdbTools:
+    def test_three_tools_defined(self):
+        assert len(TMDB_TOOLS) == 3
+
+    def test_tool_names(self):
+        names = {t["name"] for t in TMDB_TOOLS}
+        assert names == {"search_actor", "search_movie", "get_movie_cast"}
+
+    def test_all_have_required_fields(self):
+        for tool in TMDB_TOOLS:
+            assert "name" in tool
+            assert "description" in tool
+            assert "input_schema" in tool
+            schema = tool["input_schema"]
+            assert schema["type"] == "object"
+            assert "properties" in schema
+            assert "required" in schema
+
+    def test_required_params_exist_in_properties(self):
+        for tool in TMDB_TOOLS:
+            schema = tool["input_schema"]
+            for req in schema["required"]:
+                assert req in schema["properties"], f"{tool['name']} requires '{req}' but it's not in properties"
+
+
+class TestWebSearchTool:
+    def test_has_name_and_type(self):
+        assert WEB_SEARCH_TOOL["name"] == "web_search"
+        assert "type" in WEB_SEARCH_TOOL
+
+
+class TestAllTools:
+    def test_includes_tmdb_and_web_search(self):
+        names = {t["name"] for t in ALL_TOOLS}
+        assert "search_actor" in names
+        assert "search_movie" in names
+        assert "get_movie_cast" in names
+        assert "web_search" in names
+
+    def test_length(self):
+        assert len(ALL_TOOLS) == len(TMDB_TOOLS) + 1

--- a/backend/tests/test_definitions.py
+++ b/backend/tests/test_definitions.py
@@ -23,7 +23,9 @@ class TestTmdbTools:
         for tool in TMDB_TOOLS:
             schema = tool["input_schema"]
             for req in schema["required"]:
-                assert req in schema["properties"], f"{tool['name']} requires '{req}' but it's not in properties"
+                assert (
+                    req in schema["properties"]
+                ), f"{tool['name']} requires '{req}' but it's not in properties"
 
 
 class TestWebSearchTool:

--- a/backend/tests/test_example.py
+++ b/backend/tests/test_example.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert 1 + 1 == 2

--- a/backend/tests/test_extract_json.py
+++ b/backend/tests/test_extract_json.py
@@ -1,0 +1,64 @@
+from agents.validation_agent import _extract_json
+
+
+class TestRawJson:
+    def test_clean_json(self):
+        result = _extract_json('{"valid": true, "explanation": "Correct!"}')
+        assert result == {"valid": True, "explanation": "Correct!"}
+
+    def test_with_whitespace(self):
+        result = _extract_json('  {"valid": false}  ')
+        assert result == {"valid": False}
+
+
+class TestMarkdownFenced:
+    def test_json_fence(self):
+        text = '```json\n{"valid": true, "explanation": "Both actors found."}\n```'
+        result = _extract_json(text)
+        assert result["valid"] is True
+
+    def test_bare_fence(self):
+        text = '```\n{"valid": false, "explanation": "Not found."}\n```'
+        result = _extract_json(text)
+        assert result["valid"] is False
+
+    def test_nested_backticks(self):
+        text = '```json\n{"valid": true}\n```\n'
+        result = _extract_json(text)
+        assert result == {"valid": True}
+
+
+class TestEmbeddedInProse:
+    def test_json_surrounded_by_text(self):
+        text = 'Here is the result: {"valid": true, "explanation": "Found!"} Hope that helps.'
+        result = _extract_json(text)
+        assert result["valid"] is True
+
+    def test_json_after_prose(self):
+        text = 'After checking the database, I found:\n{"valid": false, "explanation": "Actor not in cast."}'
+        result = _extract_json(text)
+        assert result["valid"] is False
+
+
+class TestFullValidationShape:
+    def test_complete_response(self):
+        text = '{"valid": true, "explanation": "Both found.", "movie_id": 76203, "movie_title": "12 Years a Slave", "movie_year": "2013", "poster_url": null, "backdrop_url": null, "from_actor_found": true, "to_actor_found": true}'
+        result = _extract_json(text)
+        assert result["valid"] is True
+        assert result["movie_id"] == 76203
+        assert result["poster_url"] is None
+        assert result["from_actor_found"] is True
+
+
+class TestInvalidInput:
+    def test_no_json(self):
+        assert _extract_json("This is just plain text.") is None
+
+    def test_empty_string(self):
+        assert _extract_json("") is None
+
+    def test_malformed_json(self):
+        assert _extract_json("{valid: true}") is None
+
+    def test_truncated_json(self):
+        assert _extract_json('{"valid": true, "explanation":') is None

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -14,6 +14,7 @@ from models.game import (
 
 # --- Actor ---
 
+
 class TestActor:
     def test_basic(self):
         a = Actor(name="Brad Pitt", id=287)
@@ -22,7 +23,11 @@ class TestActor:
         assert a.profile_url is None
 
     def test_with_profile_url(self):
-        a = Actor(name="Brad Pitt", id=287, profile_url="https://image.tmdb.org/t/p/w500/abc.jpg")
+        a = Actor(
+            name="Brad Pitt",
+            id=287,
+            profile_url="https://image.tmdb.org/t/p/w500/abc.jpg",
+        )
         assert a.profile_url == "https://image.tmdb.org/t/p/w500/abc.jpg"
 
     def test_missing_required_field(self):
@@ -40,6 +45,7 @@ class TestActor:
 
 
 # --- MovieStep ---
+
 
 class TestMovieStep:
     def test_basic(self):
@@ -73,6 +79,7 @@ class TestMovieStep:
 
 # --- ActorStep ---
 
+
 class TestActorStep:
     def test_basic(self):
         a = ActorStep(type="actor", name="Michael Fassbender", id=17288)
@@ -90,9 +97,14 @@ class TestActorStep:
 
 # --- Move ---
 
+
 class TestMove:
     def test_minimal(self):
-        m = Move(from_actor="Brad Pitt", movie="12 Years a Slave", to_actor="Michael Fassbender")
+        m = Move(
+            from_actor="Brad Pitt",
+            movie="12 Years a Slave",
+            to_actor="Michael Fassbender",
+        )
         assert m.movie_id is None
         assert m.movie_title is None
         assert m.movie_year is None
@@ -113,11 +125,19 @@ class TestMove:
         assert m.movie_id == 76203
 
     def test_round_trip(self):
-        m = Move(from_actor="A", movie="B", to_actor="C", movie_id=1, movie_title="B", movie_year="2020")
+        m = Move(
+            from_actor="A",
+            movie="B",
+            to_actor="C",
+            movie_id=1,
+            movie_title="B",
+            movie_year="2020",
+        )
         assert Move(**m.model_dump()) == m
 
 
 # --- MoveRequest ---
+
 
 class TestMoveRequest:
     def test_basic(self):
@@ -131,6 +151,7 @@ class TestMoveRequest:
 
 
 # --- MoveResponse ---
+
 
 class TestMoveResponse:
     def test_valid_move(self):
@@ -177,6 +198,7 @@ class TestMoveResponse:
 
 # --- NewGameResponse ---
 
+
 class TestNewGameResponse:
     def test_basic(self):
         r = NewGameResponse(
@@ -192,6 +214,7 @@ class TestNewGameResponse:
 
 
 # --- GameState ---
+
 
 class TestGameState:
     def test_empty_game(self):
@@ -210,7 +233,11 @@ class TestGameState:
         assert g.created_at is None
 
     def test_with_moves(self):
-        move = Move(from_actor="Brad Pitt", movie="12 Years a Slave", to_actor="Michael Fassbender")
+        move = Move(
+            from_actor="Brad Pitt",
+            movie="12 Years a Slave",
+            to_actor="Michael Fassbender",
+        )
         g = GameState(
             id="abc-123",
             start_actor=Actor(name="Brad Pitt", id=287),
@@ -238,7 +265,11 @@ class TestGameState:
             )
 
     def test_round_trip(self):
-        move = Move(from_actor="Brad Pitt", movie="12 Years a Slave", to_actor="Michael Fassbender")
+        move = Move(
+            from_actor="Brad Pitt",
+            movie="12 Years a Slave",
+            to_actor="Michael Fassbender",
+        )
         g = GameState(
             id="abc-123",
             start_actor=Actor(name="Brad Pitt", id=287),

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,253 @@
+import pytest
+from pydantic import ValidationError
+from models.game import (
+    Actor,
+    MovieStep,
+    ActorStep,
+    Move,
+    GameState,
+    NewGameResponse,
+    MoveRequest,
+    MoveResponse,
+)
+
+
+# --- Actor ---
+
+class TestActor:
+    def test_basic(self):
+        a = Actor(name="Brad Pitt", id=287)
+        assert a.name == "Brad Pitt"
+        assert a.id == 287
+        assert a.profile_url is None
+
+    def test_with_profile_url(self):
+        a = Actor(name="Brad Pitt", id=287, profile_url="https://image.tmdb.org/t/p/w500/abc.jpg")
+        assert a.profile_url == "https://image.tmdb.org/t/p/w500/abc.jpg"
+
+    def test_missing_required_field(self):
+        with pytest.raises(ValidationError):
+            Actor(name="Brad Pitt")
+
+    def test_wrong_id_type(self):
+        with pytest.raises(ValidationError):
+            Actor(name="Brad Pitt", id="not_an_int")
+
+    def test_round_trip(self):
+        a = Actor(name="Brad Pitt", id=287, profile_url="https://example.com/img.jpg")
+        d = a.model_dump()
+        assert Actor(**d) == a
+
+
+# --- MovieStep ---
+
+class TestMovieStep:
+    def test_basic(self):
+        m = MovieStep(type="movie", title="12 Years a Slave", id=76203)
+        assert m.type == "movie"
+        assert m.title == "12 Years a Slave"
+        assert m.year is None
+        assert m.poster_url is None
+        assert m.backdrop_url is None
+
+    def test_with_all_fields(self):
+        m = MovieStep(
+            type="movie",
+            title="12 Years a Slave",
+            id=76203,
+            year="2013",
+            poster_url="https://image.tmdb.org/t/p/w500/poster.jpg",
+            backdrop_url="https://image.tmdb.org/t/p/w1280/backdrop.jpg",
+        )
+        assert m.year == "2013"
+        assert m.poster_url is not None
+
+    def test_wrong_type_literal(self):
+        with pytest.raises(ValidationError):
+            MovieStep(type="actor", title="12 Years a Slave", id=76203)
+
+    def test_round_trip(self):
+        m = MovieStep(type="movie", title="12 Years a Slave", id=76203, year="2013")
+        assert MovieStep(**m.model_dump()) == m
+
+
+# --- ActorStep ---
+
+class TestActorStep:
+    def test_basic(self):
+        a = ActorStep(type="actor", name="Michael Fassbender", id=17288)
+        assert a.type == "actor"
+        assert a.profile_url is None
+
+    def test_wrong_type_literal(self):
+        with pytest.raises(ValidationError):
+            ActorStep(type="movie", name="Michael Fassbender", id=17288)
+
+    def test_round_trip(self):
+        a = ActorStep(type="actor", name="Michael Fassbender", id=17288)
+        assert ActorStep(**a.model_dump()) == a
+
+
+# --- Move ---
+
+class TestMove:
+    def test_minimal(self):
+        m = Move(from_actor="Brad Pitt", movie="12 Years a Slave", to_actor="Michael Fassbender")
+        assert m.movie_id is None
+        assert m.movie_title is None
+        assert m.movie_year is None
+        assert m.poster_url is None
+        assert m.backdrop_url is None
+
+    def test_with_tmdb_metadata(self):
+        m = Move(
+            from_actor="Brad Pitt",
+            movie="12 Years a Slave",
+            to_actor="Michael Fassbender",
+            movie_id=76203,
+            movie_title="12 Years a Slave",
+            movie_year="2013",
+            poster_url="https://image.tmdb.org/t/p/w500/poster.jpg",
+            backdrop_url="https://image.tmdb.org/t/p/w1280/backdrop.jpg",
+        )
+        assert m.movie_id == 76203
+
+    def test_round_trip(self):
+        m = Move(from_actor="A", movie="B", to_actor="C", movie_id=1, movie_title="B", movie_year="2020")
+        assert Move(**m.model_dump()) == m
+
+
+# --- MoveRequest ---
+
+class TestMoveRequest:
+    def test_basic(self):
+        r = MoveRequest(movie="The Dark Knight", next_actor="Heath Ledger")
+        assert r.movie == "The Dark Knight"
+        assert r.next_actor == "Heath Ledger"
+
+    def test_missing_field(self):
+        with pytest.raises(ValidationError):
+            MoveRequest(movie="The Dark Knight")
+
+
+# --- MoveResponse ---
+
+class TestMoveResponse:
+    def test_valid_move(self):
+        r = MoveResponse(
+            valid=True,
+            explanation="Correct!",
+            movie_id=155,
+            movie_title="The Dark Knight",
+            movie_year="2008",
+            game_status="in_progress",
+            current_actor=Actor(name="Heath Ledger", id=1810),
+        )
+        assert r.valid is True
+        assert r.game_status == "in_progress"
+
+    def test_invalid_move(self):
+        r = MoveResponse(
+            valid=False,
+            explanation="Actor not found in cast.",
+            game_status="in_progress",
+            current_actor=Actor(name="Brad Pitt", id=287),
+        )
+        assert r.valid is False
+        assert r.movie_id is None
+
+    def test_won_status(self):
+        r = MoveResponse(
+            valid=True,
+            explanation="Correct!",
+            game_status="won",
+            current_actor=Actor(name="Colin Firth", id=1891),
+        )
+        assert r.game_status == "won"
+
+    def test_invalid_game_status(self):
+        with pytest.raises(ValidationError):
+            MoveResponse(
+                valid=True,
+                explanation="Correct!",
+                game_status="lost",
+                current_actor=Actor(name="Brad Pitt", id=287),
+            )
+
+
+# --- NewGameResponse ---
+
+class TestNewGameResponse:
+    def test_basic(self):
+        r = NewGameResponse(
+            game_id="abc-123",
+            start_actor=Actor(name="Brad Pitt", id=287),
+            end_actor=Actor(name="Colin Firth", id=1891),
+            difficulty="medium",
+            min_moves=3,
+        )
+        assert r.game_id == "abc-123"
+        assert r.start_actor.name == "Brad Pitt"
+        assert r.min_moves == 3
+
+
+# --- GameState ---
+
+class TestGameState:
+    def test_empty_game(self):
+        g = GameState(
+            id="abc-123",
+            start_actor=Actor(name="Brad Pitt", id=287),
+            end_actor=Actor(name="Colin Firth", id=1891),
+            difficulty="medium",
+            min_moves=3,
+            current_actor=Actor(name="Brad Pitt", id=287),
+            moves=[],
+            status="in_progress",
+        )
+        assert g.moves == []
+        assert g.status == "in_progress"
+        assert g.created_at is None
+
+    def test_with_moves(self):
+        move = Move(from_actor="Brad Pitt", movie="12 Years a Slave", to_actor="Michael Fassbender")
+        g = GameState(
+            id="abc-123",
+            start_actor=Actor(name="Brad Pitt", id=287),
+            end_actor=Actor(name="Colin Firth", id=1891),
+            difficulty="medium",
+            min_moves=3,
+            current_actor=Actor(name="Michael Fassbender", id=17288),
+            moves=[move],
+            status="in_progress",
+        )
+        assert len(g.moves) == 1
+        assert g.current_actor.name == "Michael Fassbender"
+
+    def test_invalid_status(self):
+        with pytest.raises(ValidationError):
+            GameState(
+                id="abc-123",
+                start_actor=Actor(name="Brad Pitt", id=287),
+                end_actor=Actor(name="Colin Firth", id=1891),
+                difficulty="medium",
+                min_moves=3,
+                current_actor=Actor(name="Brad Pitt", id=287),
+                moves=[],
+                status="lost",
+            )
+
+    def test_round_trip(self):
+        move = Move(from_actor="Brad Pitt", movie="12 Years a Slave", to_actor="Michael Fassbender")
+        g = GameState(
+            id="abc-123",
+            start_actor=Actor(name="Brad Pitt", id=287),
+            end_actor=Actor(name="Colin Firth", id=1891),
+            difficulty="medium",
+            min_moves=3,
+            current_actor=Actor(name="Michael Fassbender", id=17288),
+            moves=[move],
+            status="in_progress",
+            created_at="2026-03-17T00:00:00",
+        )
+        assert GameState(**g.model_dump()) == g

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,0 +1,252 @@
+import sqlite3
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+from main import app
+from database import init_db
+from routes.game import _reached_end
+
+
+# --- Pure logic: _reached_end ---
+
+class TestReachedEnd:
+    def test_match_by_id(self):
+        assert _reached_end(1891, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+
+    def test_match_by_name_fallback(self):
+        assert _reached_end(0, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+
+    def test_case_insensitive_name(self):
+        assert _reached_end(0, "colin firth", {"name": "Colin Firth", "id": 0}) is True
+
+    def test_whitespace_stripped(self):
+        assert _reached_end(0, "  Colin Firth  ", {"name": "Colin Firth", "id": 0}) is True
+
+    def test_no_match(self):
+        assert _reached_end(287, "Brad Pitt", {"name": "Colin Firth", "id": 1891}) is False
+
+    def test_id_zero_falls_through_to_name(self):
+        assert _reached_end(0, "Brad Pitt", {"name": "Colin Firth", "id": 0}) is False
+
+    def test_different_id_same_name(self):
+        """Name match wins even if IDs differ (one is 0)."""
+        assert _reached_end(0, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+
+    def test_same_id_different_name(self):
+        """ID match wins regardless of name."""
+        assert _reached_end(1891, "Sir Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+
+
+# --- FastAPI integration tests ---
+
+class _NoCloseConnection:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def close(self):
+        pass
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def _mock_puzzle():
+    return {
+        "start_actor": {"name": "Brad Pitt", "id": 287, "profile_url": None},
+        "end_actor": {"name": "Colin Firth", "id": 1891, "profile_url": None},
+        "difficulty": "medium",
+        "min_moves": 3,
+        "known_solution": [
+            {"type": "actor", "name": "Brad Pitt", "id": 287},
+            {"type": "movie", "title": "12 Years a Slave", "id": 76203},
+            {"type": "actor", "name": "Michael Fassbender", "id": 17288},
+            {"type": "movie", "title": "X-Men: Apocalypse", "id": 246655},
+            {"type": "actor", "name": "Nicholas Hoult", "id": 30614},
+            {"type": "movie", "title": "A Single Man", "id": 24420},
+            {"type": "actor", "name": "Colin Firth", "id": 1891},
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def use_in_memory_db():
+    conn = sqlite3.connect("file::memory:?cache=shared", uri=True, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+
+    def make_wrapper():
+        return _NoCloseConnection(conn)
+
+    with patch("database.get_db", side_effect=make_wrapper):
+        init_db()
+        yield
+    conn.close()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestNewGame:
+    def test_creates_game(self, client):
+        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+            res = client.post("/game/new?difficulty=medium")
+
+        assert res.status_code == 200
+        data = res.json()
+        assert "game_id" in data
+        assert data["start_actor"]["name"] == "Brad Pitt"
+        assert data["end_actor"]["name"] == "Colin Firth"
+        assert data["difficulty"] == "medium"
+        assert data["min_moves"] == 3
+
+    def test_invalid_difficulty(self, client):
+        res = client.post("/game/new?difficulty=impossible")
+        assert res.status_code == 400
+
+    def test_default_difficulty(self, client):
+        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+            res = client.post("/game/new")
+
+        assert res.status_code == 200
+        assert res.json()["difficulty"] == "medium"
+
+
+class TestGetGame:
+    def test_get_existing_game(self, client):
+        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+            create_res = client.post("/game/new?difficulty=medium")
+        game_id = create_res.json()["game_id"]
+
+        res = client.get(f"/game/{game_id}")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["id"] == game_id
+        assert data["status"] == "in_progress"
+        assert data["moves"] == []
+        assert data["current_actor"]["name"] == "Brad Pitt"
+
+    def test_get_nonexistent_game(self, client):
+        res = client.get("/game/does-not-exist")
+        assert res.status_code == 404
+
+
+class TestMakeMove:
+    def _create_game(self, client):
+        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+            res = client.post("/game/new?difficulty=medium")
+        return res.json()["game_id"]
+
+    def test_valid_move(self, client):
+        game_id = self._create_game(client)
+
+        mock_validation = {
+            "valid": True,
+            "explanation": "Both actors appear in 12 Years a Slave.",
+            "movie_id": 76203,
+            "movie_title": "12 Years a Slave",
+            "movie_year": "2013",
+            "poster_url": None,
+            "backdrop_url": None,
+        }
+        mock_person = {"name": "Michael Fassbender", "id": 17288, "profile_url": None}
+
+        with (
+            patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation),
+            patch("routes.game.tmdb.search_person", new_callable=AsyncMock, return_value=mock_person),
+        ):
+            res = client.post(
+                f"/game/{game_id}/move",
+                json={"movie": "12 Years a Slave", "next_actor": "Michael Fassbender"},
+            )
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["valid"] is True
+        assert data["game_status"] == "in_progress"
+        assert data["current_actor"]["name"] == "Michael Fassbender"
+        assert data["movie_title"] == "12 Years a Slave"
+
+    def test_invalid_move(self, client):
+        game_id = self._create_game(client)
+
+        mock_validation = {
+            "valid": False,
+            "explanation": "Actor not found in cast.",
+        }
+
+        with patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation):
+            res = client.post(
+                f"/game/{game_id}/move",
+                json={"movie": "The Matrix", "next_actor": "Brad Pitt"},
+            )
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["valid"] is False
+        assert data["game_status"] == "in_progress"
+        assert data["current_actor"]["name"] == "Brad Pitt"  # unchanged
+
+    def test_winning_move(self, client):
+        game_id = self._create_game(client)
+
+        mock_validation = {
+            "valid": True,
+            "explanation": "Correct!",
+            "movie_id": 24420,
+            "movie_title": "A Single Man",
+            "movie_year": "2009",
+            "poster_url": None,
+            "backdrop_url": None,
+        }
+        mock_person = {"name": "Colin Firth", "id": 1891, "profile_url": None}
+
+        with (
+            patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation),
+            patch("routes.game.tmdb.search_person", new_callable=AsyncMock, return_value=mock_person),
+        ):
+            res = client.post(
+                f"/game/{game_id}/move",
+                json={"movie": "A Single Man", "next_actor": "Colin Firth"},
+            )
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["valid"] is True
+        assert data["game_status"] == "won"
+
+    def test_move_on_nonexistent_game(self, client):
+        res = client.post(
+            "/game/does-not-exist/move",
+            json={"movie": "Test", "next_actor": "Test"},
+        )
+        assert res.status_code == 404
+
+    def test_move_on_finished_game(self, client):
+        game_id = self._create_game(client)
+
+        # Win the game first
+        mock_validation = {"valid": True, "explanation": "Correct!", "movie_id": 1, "movie_title": "T", "movie_year": "2000", "poster_url": None, "backdrop_url": None}
+        mock_person = {"name": "Colin Firth", "id": 1891, "profile_url": None}
+
+        with (
+            patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation),
+            patch("routes.game.tmdb.search_person", new_callable=AsyncMock, return_value=mock_person),
+        ):
+            client.post(f"/game/{game_id}/move", json={"movie": "X", "next_actor": "Colin Firth"})
+
+        # Try another move
+        res = client.post(f"/game/{game_id}/move", json={"movie": "Y", "next_actor": "Z"})
+        assert res.status_code == 400
+
+    def test_move_missing_fields(self, client):
+        game_id = self._create_game(client)
+        res = client.post(f"/game/{game_id}/move", json={"movie": "Test"})
+        assert res.status_code == 422
+
+
+class TestHealthEndpoint:
+    def test_health(self, client):
+        res = client.get("/health")
+        assert res.status_code == 200
+        assert res.json() == {"status": "ok"}

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -9,35 +9,51 @@ from routes.game import _reached_end
 
 # --- Pure logic: _reached_end ---
 
+
 class TestReachedEnd:
     def test_match_by_id(self):
-        assert _reached_end(1891, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+        assert (
+            _reached_end(1891, "Colin Firth", {"name": "Colin Firth", "id": 1891})
+            is True
+        )
 
     def test_match_by_name_fallback(self):
-        assert _reached_end(0, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+        assert (
+            _reached_end(0, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+        )
 
     def test_case_insensitive_name(self):
         assert _reached_end(0, "colin firth", {"name": "Colin Firth", "id": 0}) is True
 
     def test_whitespace_stripped(self):
-        assert _reached_end(0, "  Colin Firth  ", {"name": "Colin Firth", "id": 0}) is True
+        assert (
+            _reached_end(0, "  Colin Firth  ", {"name": "Colin Firth", "id": 0}) is True
+        )
 
     def test_no_match(self):
-        assert _reached_end(287, "Brad Pitt", {"name": "Colin Firth", "id": 1891}) is False
+        assert (
+            _reached_end(287, "Brad Pitt", {"name": "Colin Firth", "id": 1891}) is False
+        )
 
     def test_id_zero_falls_through_to_name(self):
         assert _reached_end(0, "Brad Pitt", {"name": "Colin Firth", "id": 0}) is False
 
     def test_different_id_same_name(self):
         """Name match wins even if IDs differ (one is 0)."""
-        assert _reached_end(0, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+        assert (
+            _reached_end(0, "Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+        )
 
     def test_same_id_different_name(self):
         """ID match wins regardless of name."""
-        assert _reached_end(1891, "Sir Colin Firth", {"name": "Colin Firth", "id": 1891}) is True
+        assert (
+            _reached_end(1891, "Sir Colin Firth", {"name": "Colin Firth", "id": 1891})
+            is True
+        )
 
 
 # --- FastAPI integration tests ---
+
 
 class _NoCloseConnection:
     def __init__(self, conn):
@@ -70,7 +86,9 @@ def _mock_puzzle():
 
 @pytest.fixture(autouse=True)
 def use_in_memory_db():
-    conn = sqlite3.connect("file::memory:?cache=shared", uri=True, check_same_thread=False)
+    conn = sqlite3.connect(
+        "file::memory:?cache=shared", uri=True, check_same_thread=False
+    )
     conn.row_factory = sqlite3.Row
 
     def make_wrapper():
@@ -89,7 +107,11 @@ def client():
 
 class TestNewGame:
     def test_creates_game(self, client):
-        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+        with patch(
+            "routes.game.generate_puzzle",
+            new_callable=AsyncMock,
+            return_value=_mock_puzzle(),
+        ):
             res = client.post("/game/new?difficulty=medium")
 
         assert res.status_code == 200
@@ -105,7 +127,11 @@ class TestNewGame:
         assert res.status_code == 400
 
     def test_default_difficulty(self, client):
-        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+        with patch(
+            "routes.game.generate_puzzle",
+            new_callable=AsyncMock,
+            return_value=_mock_puzzle(),
+        ):
             res = client.post("/game/new")
 
         assert res.status_code == 200
@@ -114,7 +140,11 @@ class TestNewGame:
 
 class TestGetGame:
     def test_get_existing_game(self, client):
-        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+        with patch(
+            "routes.game.generate_puzzle",
+            new_callable=AsyncMock,
+            return_value=_mock_puzzle(),
+        ):
             create_res = client.post("/game/new?difficulty=medium")
         game_id = create_res.json()["game_id"]
 
@@ -133,7 +163,11 @@ class TestGetGame:
 
 class TestMakeMove:
     def _create_game(self, client):
-        with patch("routes.game.generate_puzzle", new_callable=AsyncMock, return_value=_mock_puzzle()):
+        with patch(
+            "routes.game.generate_puzzle",
+            new_callable=AsyncMock,
+            return_value=_mock_puzzle(),
+        ):
             res = client.post("/game/new?difficulty=medium")
         return res.json()["game_id"]
 
@@ -152,8 +186,16 @@ class TestMakeMove:
         mock_person = {"name": "Michael Fassbender", "id": 17288, "profile_url": None}
 
         with (
-            patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation),
-            patch("routes.game.tmdb.search_person", new_callable=AsyncMock, return_value=mock_person),
+            patch(
+                "routes.game.validate_move",
+                new_callable=AsyncMock,
+                return_value=mock_validation,
+            ),
+            patch(
+                "routes.game.tmdb.search_person",
+                new_callable=AsyncMock,
+                return_value=mock_person,
+            ),
         ):
             res = client.post(
                 f"/game/{game_id}/move",
@@ -175,7 +217,11 @@ class TestMakeMove:
             "explanation": "Actor not found in cast.",
         }
 
-        with patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation):
+        with patch(
+            "routes.game.validate_move",
+            new_callable=AsyncMock,
+            return_value=mock_validation,
+        ):
             res = client.post(
                 f"/game/{game_id}/move",
                 json={"movie": "The Matrix", "next_actor": "Brad Pitt"},
@@ -202,8 +248,16 @@ class TestMakeMove:
         mock_person = {"name": "Colin Firth", "id": 1891, "profile_url": None}
 
         with (
-            patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation),
-            patch("routes.game.tmdb.search_person", new_callable=AsyncMock, return_value=mock_person),
+            patch(
+                "routes.game.validate_move",
+                new_callable=AsyncMock,
+                return_value=mock_validation,
+            ),
+            patch(
+                "routes.game.tmdb.search_person",
+                new_callable=AsyncMock,
+                return_value=mock_person,
+            ),
         ):
             res = client.post(
                 f"/game/{game_id}/move",
@@ -226,17 +280,38 @@ class TestMakeMove:
         game_id = self._create_game(client)
 
         # Win the game first
-        mock_validation = {"valid": True, "explanation": "Correct!", "movie_id": 1, "movie_title": "T", "movie_year": "2000", "poster_url": None, "backdrop_url": None}
+        mock_validation = {
+            "valid": True,
+            "explanation": "Correct!",
+            "movie_id": 1,
+            "movie_title": "T",
+            "movie_year": "2000",
+            "poster_url": None,
+            "backdrop_url": None,
+        }
         mock_person = {"name": "Colin Firth", "id": 1891, "profile_url": None}
 
         with (
-            patch("routes.game.validate_move", new_callable=AsyncMock, return_value=mock_validation),
-            patch("routes.game.tmdb.search_person", new_callable=AsyncMock, return_value=mock_person),
+            patch(
+                "routes.game.validate_move",
+                new_callable=AsyncMock,
+                return_value=mock_validation,
+            ),
+            patch(
+                "routes.game.tmdb.search_person",
+                new_callable=AsyncMock,
+                return_value=mock_person,
+            ),
         ):
-            client.post(f"/game/{game_id}/move", json={"movie": "X", "next_actor": "Colin Firth"})
+            client.post(
+                f"/game/{game_id}/move",
+                json={"movie": "X", "next_actor": "Colin Firth"},
+            )
 
         # Try another move
-        res = client.post(f"/game/{game_id}/move", json={"movie": "Y", "next_actor": "Z"})
+        res = client.post(
+            f"/game/{game_id}/move", json={"movie": "Y", "next_actor": "Z"}
+        )
         assert res.status_code == 400
 
     def test_move_missing_fields(self, client):

--- a/backend/tests/test_tmdb.py
+++ b/backend/tests/test_tmdb.py
@@ -1,0 +1,303 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from tools.tmdb import TMDbClient
+
+
+@pytest.fixture
+def client():
+    return TMDbClient()
+
+
+# --- search_person ---
+
+class TestSearchPerson:
+    @pytest.mark.asyncio
+    async def test_returns_first_result(self, client):
+        mock_response = {
+            "results": [
+                {
+                    "id": 287,
+                    "name": "Brad Pitt",
+                    "popularity": 25.3,
+                    "profile_path": "/abc.jpg",
+                    "known_for": [
+                        {"title": "Fight Club"},
+                        {"title": "Troy"},
+                    ],
+                }
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.search_person("Brad Pitt")
+
+        assert result["id"] == 287
+        assert result["name"] == "Brad Pitt"
+        assert result["popularity"] == 25.3
+        assert result["profile_url"].endswith("/abc.jpg")
+        assert "Fight Club" in result["known_for"]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_results(self, client):
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"results": []}):
+            result = await client.search_person("Nonexistent Person")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_profile_path(self, client):
+        mock_response = {
+            "results": [{"id": 1, "name": "Test", "known_for": []}]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.search_person("Test")
+
+        assert result["profile_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_known_for_with_tv_shows(self, client):
+        mock_response = {
+            "results": [
+                {
+                    "id": 1,
+                    "name": "Test",
+                    "known_for": [
+                        {"title": "A Movie"},
+                        {"name": "A TV Show"},  # TV uses "name" not "title"
+                    ],
+                }
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.search_person("Test")
+
+        assert result["known_for"] == ["A Movie", "A TV Show"]
+
+
+# --- get_person_movies ---
+
+class TestGetPersonMovies:
+    @pytest.mark.asyncio
+    async def test_returns_sorted_by_popularity(self, client):
+        mock_response = {
+            "cast": [
+                {"id": 1, "title": "Unpopular", "popularity": 2, "release_date": "2020-01-01"},
+                {"id": 2, "title": "Popular", "popularity": 50, "release_date": "2019-06-15"},
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_movies(287)
+
+        assert result[0]["title"] == "Popular"
+        assert result[1]["title"] == "Unpopular"
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self, client):
+        mock_response = {
+            "cast": [
+                {"id": i, "title": f"Movie {i}", "popularity": i}
+                for i in range(10)
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_movies(287, limit=3)
+
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_extracts_year_from_release_date(self, client):
+        mock_response = {
+            "cast": [{"id": 1, "title": "Test", "popularity": 1, "release_date": "2013-10-18"}]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_movies(287)
+
+        assert result[0]["year"] == "2013"
+
+    @pytest.mark.asyncio
+    async def test_missing_release_date(self, client):
+        mock_response = {
+            "cast": [{"id": 1, "title": "Test", "popularity": 1}]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_movies(287)
+
+        assert result[0]["year"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_release_date(self, client):
+        mock_response = {
+            "cast": [{"id": 1, "title": "Test", "popularity": 1, "release_date": ""}]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_movies(287)
+
+        assert result[0]["year"] is None
+
+    @pytest.mark.asyncio
+    async def test_image_urls(self, client):
+        mock_response = {
+            "cast": [
+                {
+                    "id": 1,
+                    "title": "Test",
+                    "popularity": 1,
+                    "poster_path": "/poster.jpg",
+                    "backdrop_path": "/backdrop.jpg",
+                }
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_movies(287)
+
+        assert "w500" in result[0]["poster_url"]
+        assert "w1280" in result[0]["backdrop_url"]
+
+
+# --- search_movie ---
+
+class TestSearchMovie:
+    @pytest.mark.asyncio
+    async def test_returns_first_result(self, client):
+        mock_response = {
+            "results": [
+                {
+                    "id": 76203,
+                    "title": "12 Years a Slave",
+                    "release_date": "2013-10-18",
+                    "poster_path": "/poster.jpg",
+                    "backdrop_path": "/backdrop.jpg",
+                }
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.search_movie("12 Years a Slave")
+
+        assert result["id"] == 76203
+        assert result["title"] == "12 Years a Slave"
+        assert result["year"] == "2013"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_results(self, client):
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"results": []}):
+            result = await client.search_movie("xyznonexistent")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_passes_year_param(self, client):
+        mock_get = AsyncMock(return_value={"results": [{"id": 1, "title": "Test", "release_date": "2013-01-01"}]})
+        with patch.object(client, "_get", mock_get):
+            await client.search_movie("Test", year=2013)
+
+        args, kwargs = mock_get.call_args
+        assert kwargs.get("year") == 2013 or args[1].get("year") == 2013
+
+
+# --- get_movie_cast ---
+
+class TestGetMovieCast:
+    @pytest.mark.asyncio
+    async def test_returns_cast_list(self, client):
+        mock_response = {
+            "cast": [
+                {"id": 287, "name": "Brad Pitt", "character": "Edwin Epps", "order": 0, "profile_path": "/brad.jpg"},
+                {"id": 17288, "name": "Michael Fassbender", "character": "Bass", "order": 1},
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_movie_cast(76203)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "Brad Pitt"
+        assert result[0]["character"] == "Edwin Epps"
+        assert result[0]["order"] == 0
+        assert result[0]["profile_url"].endswith("/brad.jpg")
+        assert result[1]["profile_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_cast(self, client):
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"cast": []}):
+            result = await client.get_movie_cast(99999)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_missing_character_defaults(self, client):
+        mock_response = {"cast": [{"id": 1, "name": "Test"}]}
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_movie_cast(1)
+
+        assert result[0]["character"] == ""
+        assert result[0]["order"] == 999
+
+
+# --- get_person_details ---
+
+class TestGetPersonDetails:
+    @pytest.mark.asyncio
+    async def test_returns_details(self, client):
+        mock_response = {"id": 287, "name": "Brad Pitt", "popularity": 25.3, "profile_path": "/brad.jpg"}
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_person_details(287)
+
+        assert result["id"] == 287
+        assert result["name"] == "Brad Pitt"
+        assert result["popularity"] == 25.3
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_error(self, client):
+        with patch.object(client, "_get", new_callable=AsyncMock, side_effect=Exception("Not found")):
+            result = await client.get_person_details(99999)
+
+        assert result is None
+
+
+# --- get_popular_people ---
+
+class TestGetPopularPeople:
+    @pytest.mark.asyncio
+    async def test_returns_people_list(self, client):
+        mock_response = {
+            "results": [
+                {
+                    "id": 287,
+                    "name": "Brad Pitt",
+                    "popularity": 25.3,
+                    "profile_path": "/brad.jpg",
+                    "known_for": [{"title": "Fight Club"}],
+                },
+                {
+                    "id": 1891,
+                    "name": "Colin Firth",
+                    "popularity": 12.1,
+                    "profile_path": None,
+                    "known_for": [{"name": "The Crown"}],
+                },
+            ]
+        }
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+            result = await client.get_popular_people(page=1)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "Brad Pitt"
+        assert result[1]["known_for"] == ["The Crown"]
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, client):
+        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"results": []}):
+            result = await client.get_popular_people()
+
+        assert result == []
+
+
+# --- _img helper ---
+
+class TestImgHelper:
+    def test_with_path(self, client):
+        assert client._img("/abc.jpg") == "https://image.tmdb.org/t/p/w500/abc.jpg"
+
+    def test_with_none(self, client):
+        assert client._img(None) is None
+
+    def test_with_custom_base(self, client):
+        assert client._img("/abc.jpg", "https://example.com") == "https://example.com/abc.jpg"

--- a/backend/tests/test_tmdb.py
+++ b/backend/tests/test_tmdb.py
@@ -10,6 +10,7 @@ def client():
 
 # --- search_person ---
 
+
 class TestSearchPerson:
     @pytest.mark.asyncio
     async def test_returns_first_result(self, client):
@@ -27,7 +28,9 @@ class TestSearchPerson:
                 }
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.search_person("Brad Pitt")
 
         assert result["id"] == 287
@@ -38,17 +41,19 @@ class TestSearchPerson:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_results(self, client):
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"results": []}):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value={"results": []}
+        ):
             result = await client.search_person("Nonexistent Person")
 
         assert result is None
 
     @pytest.mark.asyncio
     async def test_missing_profile_path(self, client):
-        mock_response = {
-            "results": [{"id": 1, "name": "Test", "known_for": []}]
-        }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        mock_response = {"results": [{"id": 1, "name": "Test", "known_for": []}]}
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.search_person("Test")
 
         assert result["profile_url"] is None
@@ -67,7 +72,9 @@ class TestSearchPerson:
                 }
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.search_person("Test")
 
         assert result["known_for"] == ["A Movie", "A TV Show"]
@@ -75,16 +82,29 @@ class TestSearchPerson:
 
 # --- get_person_movies ---
 
+
 class TestGetPersonMovies:
     @pytest.mark.asyncio
     async def test_returns_sorted_by_popularity(self, client):
         mock_response = {
             "cast": [
-                {"id": 1, "title": "Unpopular", "popularity": 2, "release_date": "2020-01-01"},
-                {"id": 2, "title": "Popular", "popularity": 50, "release_date": "2019-06-15"},
+                {
+                    "id": 1,
+                    "title": "Unpopular",
+                    "popularity": 2,
+                    "release_date": "2020-01-01",
+                },
+                {
+                    "id": 2,
+                    "title": "Popular",
+                    "popularity": 50,
+                    "release_date": "2019-06-15",
+                },
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_movies(287)
 
         assert result[0]["title"] == "Popular"
@@ -94,11 +114,12 @@ class TestGetPersonMovies:
     async def test_respects_limit(self, client):
         mock_response = {
             "cast": [
-                {"id": i, "title": f"Movie {i}", "popularity": i}
-                for i in range(10)
+                {"id": i, "title": f"Movie {i}", "popularity": i} for i in range(10)
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_movies(287, limit=3)
 
         assert len(result) == 3
@@ -106,19 +127,28 @@ class TestGetPersonMovies:
     @pytest.mark.asyncio
     async def test_extracts_year_from_release_date(self, client):
         mock_response = {
-            "cast": [{"id": 1, "title": "Test", "popularity": 1, "release_date": "2013-10-18"}]
+            "cast": [
+                {
+                    "id": 1,
+                    "title": "Test",
+                    "popularity": 1,
+                    "release_date": "2013-10-18",
+                }
+            ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_movies(287)
 
         assert result[0]["year"] == "2013"
 
     @pytest.mark.asyncio
     async def test_missing_release_date(self, client):
-        mock_response = {
-            "cast": [{"id": 1, "title": "Test", "popularity": 1}]
-        }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        mock_response = {"cast": [{"id": 1, "title": "Test", "popularity": 1}]}
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_movies(287)
 
         assert result[0]["year"] is None
@@ -128,7 +158,9 @@ class TestGetPersonMovies:
         mock_response = {
             "cast": [{"id": 1, "title": "Test", "popularity": 1, "release_date": ""}]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_movies(287)
 
         assert result[0]["year"] is None
@@ -146,7 +178,9 @@ class TestGetPersonMovies:
                 }
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_movies(287)
 
         assert "w500" in result[0]["poster_url"]
@@ -154,6 +188,7 @@ class TestGetPersonMovies:
 
 
 # --- search_movie ---
+
 
 class TestSearchMovie:
     @pytest.mark.asyncio
@@ -169,7 +204,9 @@ class TestSearchMovie:
                 }
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.search_movie("12 Years a Slave")
 
         assert result["id"] == 76203
@@ -178,14 +215,20 @@ class TestSearchMovie:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_results(self, client):
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"results": []}):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value={"results": []}
+        ):
             result = await client.search_movie("xyznonexistent")
 
         assert result is None
 
     @pytest.mark.asyncio
     async def test_passes_year_param(self, client):
-        mock_get = AsyncMock(return_value={"results": [{"id": 1, "title": "Test", "release_date": "2013-01-01"}]})
+        mock_get = AsyncMock(
+            return_value={
+                "results": [{"id": 1, "title": "Test", "release_date": "2013-01-01"}]
+            }
+        )
         with patch.object(client, "_get", mock_get):
             await client.search_movie("Test", year=2013)
 
@@ -195,16 +238,30 @@ class TestSearchMovie:
 
 # --- get_movie_cast ---
 
+
 class TestGetMovieCast:
     @pytest.mark.asyncio
     async def test_returns_cast_list(self, client):
         mock_response = {
             "cast": [
-                {"id": 287, "name": "Brad Pitt", "character": "Edwin Epps", "order": 0, "profile_path": "/brad.jpg"},
-                {"id": 17288, "name": "Michael Fassbender", "character": "Bass", "order": 1},
+                {
+                    "id": 287,
+                    "name": "Brad Pitt",
+                    "character": "Edwin Epps",
+                    "order": 0,
+                    "profile_path": "/brad.jpg",
+                },
+                {
+                    "id": 17288,
+                    "name": "Michael Fassbender",
+                    "character": "Bass",
+                    "order": 1,
+                },
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_movie_cast(76203)
 
         assert len(result) == 2
@@ -216,7 +273,9 @@ class TestGetMovieCast:
 
     @pytest.mark.asyncio
     async def test_empty_cast(self, client):
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"cast": []}):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value={"cast": []}
+        ):
             result = await client.get_movie_cast(99999)
 
         assert result == []
@@ -224,7 +283,9 @@ class TestGetMovieCast:
     @pytest.mark.asyncio
     async def test_missing_character_defaults(self, client):
         mock_response = {"cast": [{"id": 1, "name": "Test"}]}
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_movie_cast(1)
 
         assert result[0]["character"] == ""
@@ -233,11 +294,19 @@ class TestGetMovieCast:
 
 # --- get_person_details ---
 
+
 class TestGetPersonDetails:
     @pytest.mark.asyncio
     async def test_returns_details(self, client):
-        mock_response = {"id": 287, "name": "Brad Pitt", "popularity": 25.3, "profile_path": "/brad.jpg"}
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        mock_response = {
+            "id": 287,
+            "name": "Brad Pitt",
+            "popularity": 25.3,
+            "profile_path": "/brad.jpg",
+        }
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_person_details(287)
 
         assert result["id"] == 287
@@ -246,13 +315,16 @@ class TestGetPersonDetails:
 
     @pytest.mark.asyncio
     async def test_returns_none_on_error(self, client):
-        with patch.object(client, "_get", new_callable=AsyncMock, side_effect=Exception("Not found")):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, side_effect=Exception("Not found")
+        ):
             result = await client.get_person_details(99999)
 
         assert result is None
 
 
 # --- get_popular_people ---
+
 
 class TestGetPopularPeople:
     @pytest.mark.asyncio
@@ -275,7 +347,9 @@ class TestGetPopularPeople:
                 },
             ]
         }
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value=mock_response):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value=mock_response
+        ):
             result = await client.get_popular_people(page=1)
 
         assert len(result) == 2
@@ -284,13 +358,16 @@ class TestGetPopularPeople:
 
     @pytest.mark.asyncio
     async def test_empty_results(self, client):
-        with patch.object(client, "_get", new_callable=AsyncMock, return_value={"results": []}):
+        with patch.object(
+            client, "_get", new_callable=AsyncMock, return_value={"results": []}
+        ):
             result = await client.get_popular_people()
 
         assert result == []
 
 
 # --- _img helper ---
+
 
 class TestImgHelper:
     def test_with_path(self, client):
@@ -300,4 +377,7 @@ class TestImgHelper:
         assert client._img(None) is None
 
     def test_with_custom_base(self, client):
-        assert client._img("/abc.jpg", "https://example.com") == "https://example.com/abc.jpg"
+        assert (
+            client._img("/abc.jpg", "https://example.com")
+            == "https://example.com/abc.jpg"
+        )

--- a/backend/tools/definitions.py
+++ b/backend/tools/definitions.py
@@ -14,7 +14,10 @@ TMDB_TOOLS = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "name": {"type": "string", "description": "Full name of the actor to search for"},
+                "name": {
+                    "type": "string",
+                    "description": "Full name of the actor to search for",
+                },
             },
             "required": ["name"],
         },
@@ -30,7 +33,10 @@ TMDB_TOOLS = [
             "type": "object",
             "properties": {
                 "title": {"type": "string", "description": "Title of the movie"},
-                "year": {"type": "integer", "description": "Optional release year to narrow results"},
+                "year": {
+                    "type": "integer",
+                    "description": "Optional release year to narrow results",
+                },
             },
             "required": ["title"],
         },

--- a/backend/tools/tmdb.py
+++ b/backend/tools/tmdb.py
@@ -31,7 +31,9 @@ class TMDbClient:
             "name": p["name"],
             "popularity": p.get("popularity", 0),
             "profile_url": self._img(p.get("profile_path")),
-            "known_for": [m.get("title", m.get("name", "")) for m in p.get("known_for", [])],
+            "known_for": [
+                m.get("title", m.get("name", "")) for m in p.get("known_for", [])
+            ],
         }
 
     async def get_person_movies(self, person_id: int, limit: int = 20) -> list[dict]:
@@ -100,7 +102,9 @@ class TMDbClient:
                 "name": p["name"],
                 "popularity": p.get("popularity", 0),
                 "profile_url": self._img(p.get("profile_path")),
-                "known_for": [m.get("title", m.get("name", "")) for m in p.get("known_for", [])],
+                "known_for": [
+                    m.get("title", m.get("name", "")) for m in p.get("known_for", [])
+                ],
             }
             for p in data.get("results", [])
         ]


### PR DESCRIPTION
We will need tests so that we can refactor in a stable manner.

## Backend test suite

  104 tests across 7 files, all passing.

  ### Coverage

  | File | Tests | What's covered |
  |------|-------|----------------|
  | `test_models.py` | 26 | All 8 Pydantic models: construction, defaults,
  required field validation, type rejection, literal constraints, serialization
  round-trips |
  | `test_database.py` | 9 | SQLite CRUD operations (init, save, load, update)
  using in-memory DB |
  | `test_tmdb.py` | 23 | All 6 TMDb client methods + `_img` helper with mocked
  HTTP responses |
  | `test_routes.py` | 20 | `_reached_end` win-detection logic (8 cases);
  FastAPI endpoint integration for all 3 game routes + health (12 cases) with
  mocked agents and TMDb |
  | `test_config.py` | 7 | Difficulty hop ranges and actor popularity floor
  invariants |
  | `test_definitions.py` | 7 | Claude tool schema structure and completeness |
  | `test_extract_json.py` | 12 | JSON parsing from raw, markdown-fenced, and
  prose-embedded responses; invalid input handling |

  ### Not tested (by design)

  `agents/base.py` and `agents/validation_agent.py` LLM interaction — these are
  marked with TODO comments to abstract behind a testable interface (e.g.
  langchain) to allow provider substitution and local testing with Ollama.
