### PR TITLE
Add Render deployment config for backend

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  # FastAPI backend — free Web Service (spins down after 15 min idle)
+  - type: web
+    name: cinema-game-backend
+    runtime: python
+    plan: free
+    rootDir: .
+    buildCommand: pip install poetry && poetry install --only main
+    startCommand: uvicorn cinema_game_backend.main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false  # you'll set this manually in the Render dashboard
+      - key: FRONTEND_URL
+        sync: false  # set to your frontend's Render URL after deploying it


### PR DESCRIPTION
## Summary
- Adds `render.yaml` to deploy the FastAPI backend as a free Render web service
- Frontend is deployed separately from its own `cinema-frontend` repo
- `ANTHROPIC_API_KEY` and `FRONTEND_URL` must be set manually in the Render dashboard

## Test plan
- [ ] Connect `cinema_game` repo to Render — it should auto-detect `render.yaml`
- [ ] Set `ANTHROPIC_API_KEY` in Render dashboard for the backend service
- [ ] Set `FRONTEND_URL` once the frontend is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)