### PR TITLE
Fix run_agent returning None when web_search result blocks are present

### DIFF
--- a/cinema_game_backend/agents/base.py
+++ b/cinema_game_backend/agents/base.py
@@ -66,7 +66,7 @@ async def run_agent(
 
         if response.stop_reason == "end_turn":
             for block in response.content:
-                if hasattr(block, "text"):
+                if block.type == "text":
                     return block.text
             return ""
 

--- a/functional_tests/test_run_agent_loop.py
+++ b/functional_tests/test_run_agent_loop.py
@@ -11,9 +11,6 @@ These tests are slow (hitting the real Anthropic API) and require valid
 credentials. They should not run in CI.
 """
 
-import pytest
-
-
 class TestRunAgentLoop:
     """Test the agentic loop mechanics."""
 
@@ -39,9 +36,6 @@ class TestRunAgentLoop:
         # Should contain relevant information
         assert "Paris" in result or "capital" in result.lower()
 
-    @pytest.mark.xfail(
-        reason="web_search_tool_result blocks have text=None; code returns None instead of actual text response"
-    )
     async def test_single_tmdb_tool_call(self, run_agentic_loop, tmdb_tools):
         """Test that a single tool call is dispatched and result is returned.
 
@@ -65,9 +59,6 @@ search for it using the search_movie tool and report what you find."""
         # Should contain information about the movie
         assert "Matrix" in result or "movie" in result.lower()
 
-    @pytest.mark.xfail(
-        reason="web_search_tool_result blocks have text=None; code returns None instead of actual text response"
-    )
     async def test_multi_hop_tmdb_chain(self, run_agentic_loop, tmdb_tools):
         """Test that the agent handles multiple tool calls across iterations.
 
@@ -120,9 +111,6 @@ movies, search for both using search_movie and report similarities/differences."
         # Should return empty string or a partial answer, not crash
         assert isinstance(result, str)
 
-    @pytest.mark.xfail(
-        reason="web_search_tool_result blocks have text=None; code returns None instead of actual text response"
-    )
     async def test_web_search_tool_skipped_client_side(
         self, run_agentic_loop, tmdb_tools
     ):


### PR DESCRIPTION
## Summary

- Fix `run_agent` in `agents/base.py` returning `None` instead of the text response when the Anthropic API includes `web_search_tool_result` blocks in the response content
- Remove `@pytest.mark.xfail` annotations from the three functional tests that were blocked by this bug

## Root cause

The agentic loop was checking `hasattr(block, "text")` to find the final text response. `web_search_tool_result` blocks satisfy this check but have `.text = None`, so the function returned `None` before reaching the actual `TextBlock`.

The fix checks `block.type == "text"` instead, which correctly skips all non-text block types.

## Test plan

- [ ] Run functional tests locally with valid API credentials: `pytest functional_tests/test_run_agent_loop.py`
- [ ] Confirm `test_single_tmdb_tool_call`, `test_multi_hop_tmdb_chain`, and `test_web_search_tool_skipped_client_side` now pass without `xfail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)