### PR TITLE
Fix medium/hard puzzle generation exhausting retries

### DIFF
--- a/cinema_game_backend/agents/puzzle_agent.py
+++ b/cinema_game_backend/agents/puzzle_agent.py
@@ -171,9 +171,10 @@ async def generate_puzzle(difficulty: str = "medium") -> dict:
     hops = random.randint(*hop_range)
     min_pop = MIN_ACTOR_POPULARITY.get(difficulty, 4)
     no_repeat = difficulty == "easy"
-    # Reject puzzles where a shortcut shorter than the intended minimum exists.
-    # We check up to 2 hops regardless of difficulty (API cost limit).
-    shortcut_threshold = min(hop_range[0] - 1, 2)
+    # Reject only trivially easy puzzles where the two actors share a direct movie.
+    # The 2-hop check was too aggressive — popular actors are almost always 2 hops
+    # apart, causing medium/hard generation to exhaust all retries.
+    shortcut_threshold = 1
 
     for _ in range(15):
         start_actor = await _pick_popular_actor(min_pop)


### PR DESCRIPTION
## Summary
- `shortcut_threshold` was set to `min(hop_range[0] - 1, 2)`, which equals `2` for medium and hard difficulty
- The 2-hop check rejects puzzles where the two actors share a common co-star — but popular actors are almost always 2 hops apart in the movie graph, so nearly every attempt was rejected and the generator hit the 15-attempt limit
- Fix: cap the threshold at `1`, so only trivially easy puzzles (start and end actors share a direct movie) are rejected

## Test plan
- [ ] Start a medium difficulty game — should generate without error
- [ ] Start a hard difficulty game — should generate without error
- [ ] Start an easy game — behaviour unchanged (still rejects direct co-stars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)