### PR TITLE
Confidence-gated validation with TMDb context injection

### DIFF
--- a/cinema_game_backend/agents/base.py
+++ b/cinema_game_backend/agents/base.py
@@ -40,6 +40,22 @@ async def _tool_get_movie_cast(tmdb: TMDbClient, tool_input: dict) -> str:
     return json.dumps([c.model_dump(mode="json") for c in result])
 
 
+@traceable(run_type="llm", name="claude_call")
+def _call_llm_once(messages: list, system: str) -> anthropic.types.Message:
+    """Single traced LLM call without tools — for structured one-shot prompts.
+
+    Swap for provider.invoke_json(prompt, schema) when reusable-llm-provider
+    is integrated: the call site in validation_agent._validate_fast_path becomes
+    a one-line change.
+    """
+    return client.messages.create(
+        model=MODEL,
+        max_tokens=512,
+        system=system,
+        messages=messages,
+    )
+
+
 async def execute_tool(tmdb: TMDbClient, name: str, tool_input: dict) -> str:
     """Dispatch a tool call to the appropriate TMDb handler."""
     if name == "search_actor":

--- a/cinema_game_backend/agents/validation_agent.py
+++ b/cinema_game_backend/agents/validation_agent.py
@@ -1,9 +1,9 @@
 """
 Validation Agent: verifies that two actors both appeared in a named movie.
-Uses Claude with TMDb tools + web search to handle name variations and ambiguity.
 
-TODO: Abstract the LLM provider behind a testable interface (e.g. langchain)
-so we can substitute other providers or run locally with Ollama.
+Fast path: pre-fetches movie + cast from TMDb (cache-friendly), asks Claude
+to reason over the provided data in a single LLM call. Falls back to the full
+agentic loop when fast-path confidence is low or the pre-fetch fails.
 """
 
 import json
@@ -11,14 +11,31 @@ import logging
 import re
 from langsmith import traceable, trace
 from art_graph.cinema_data_providers.tmdb.client import TMDbClient
-from .base import run_agent
-from ..models.game import ValidationResult
+from .base import run_agent, _call_llm_once
+from ..models.game import Confidence, ValidationResult
 from ..tools.definitions import ALL_TOOLS
 
 logger = logging.getLogger(__name__)
 
 
-SYSTEM_PROMPT = """You are a movie trivia validator for a cinema connections game.
+FAST_PATH_SYSTEM = """You are a movie cast validator for a cinema connections game.
+
+You will be given a movie's TMDb metadata and its full cast list. Your job is to
+determine whether two named actors both appear in that cast, using fuzzy matching
+for typos, name variants, partial names, and abbreviations.
+
+Rate your confidence:
+- high: both actors clearly match (or clearly don't match) entries in the cast list
+- medium: you matched with minor name variation, abbreviation, or last-name-only
+- low: significant ambiguity — the cast list may be for the wrong film, an actor
+  is not clearly identifiable, or the cast list appears incomplete
+
+CRITICAL: Your entire response must be ONLY a raw JSON object. No prose, no markdown.
+Start with { and end with }. Shape must be exactly:
+{"valid": true|false, "explanation": "brief reason", "confidence": "high"|"medium"|"low", "movie_id": int|null, "movie_title": "str|null", "movie_year": "str|null", "poster_url": "str|null", "backdrop_url": "str|null", "from_actor_found": true|false, "to_actor_found": true|false}"""
+
+
+FALLBACK_SYSTEM = """You are a movie trivia validator for a cinema connections game.
 
 Your job is to verify whether two actors both appeared in a specific movie.
 Be thorough but efficient. Use TMDb tools to look up the movie and its cast.
@@ -26,25 +43,22 @@ If a movie title is ambiguous or might have a different exact spelling, try web_
 
 CRITICAL: Your entire response must be ONLY a raw JSON object. No prose, no markdown, no code fences.
 Start your response with { and end with }. The shape must be exactly:
-{"valid": true|false, "explanation": "brief reason", "movie_id": int|null, "movie_title": "str|null", "movie_year": "str|null", "poster_url": "str|null", "backdrop_url": "str|null", "from_actor_found": true|false, "to_actor_found": true|false}"""
+{"valid": true|false, "explanation": "brief reason", "confidence": "high", "movie_id": int|null, "movie_title": "str|null", "movie_year": "str|null", "poster_url": "str|null", "backdrop_url": "str|null", "from_actor_found": true|false, "to_actor_found": true|false}"""
 
 
 def _extract_json(text: str) -> dict | None:
     """Extract the first valid JSON object from a string, tolerating surrounding prose."""
-    # Try the full response first
     try:
         return json.loads(text.strip())
     except json.JSONDecodeError:
         pass
 
-    # Strip markdown fences and retry
     cleaned = re.sub(r"```(?:json)?", "", text).strip().strip("`").strip()
     try:
         return json.loads(cleaned)
     except json.JSONDecodeError:
         pass
 
-    # Find the first {...} block in the text
     match = re.search(r"\{[\s\S]*\}", text)
     if match:
         try:
@@ -55,52 +69,123 @@ def _extract_json(text: str) -> dict | None:
     return None
 
 
-@traceable(run_type="chain", name="validate_move")
-async def validate_move(
+@traceable(run_type="tool", name="tmdb_prefetch")
+async def _prefetch_movie_context(tmdb: TMDbClient, movie_title: str) -> dict | None:
+    """Pre-fetch movie metadata and cast from TMDb. Fast when cached."""
+    movie = await tmdb.search_movie(movie_title)
+    if not movie:
+        return None
+    cast = await tmdb.get_movie_cast(movie.id)
+    return {"movie": movie, "cast": cast}
+
+
+@traceable(run_type="chain", name="fast_path_validation")
+async def _validate_fast_path(
+    from_actor: str,
+    movie_title: str,
+    to_actor: str,
+    context: dict,
+) -> ValidationResult | None:
+    """One-shot validation using pre-fetched context. No tool calls needed.
+
+    When reusable-llm-provider is integrated, replace _call_llm_once + manual
+    parsing with: provider.invoke_json(prompt, ValidationResult)
+    """
+    movie = context["movie"]
+    cast = context["cast"]
+    cast_names = ", ".join(c.name for c in cast[:60])
+
+    prompt = (
+        f"Movie: {movie.title} ({movie.year})\n"
+        f"TMDb cast: {cast_names}\n\n"
+        f"Verify: does this cast include both '{from_actor}' and '{to_actor}'?\n"
+        f"Return only the raw JSON object."
+    )
+
+    response = _call_llm_once(
+        [{"role": "user", "content": prompt}],
+        FAST_PATH_SYSTEM,
+    )
+
+    raw = next((b.text for b in response.content if b.type == "text"), "")
+    parsed = _extract_json(raw)
+
+    if not parsed:
+        with trace(name="parse_error", run_type="tool", inputs={"raw": raw}) as t:
+            t.error = "Fast path: could not extract JSON from response"
+        return None
+
+    parsed.setdefault("movie_id", movie.id)
+    parsed.setdefault("movie_title", movie.title)
+    parsed.setdefault("movie_year", movie.year)
+    parsed.setdefault("poster_url", movie.poster_url)
+    parsed.setdefault("backdrop_url", movie.backdrop_url)
+
+    try:
+        return ValidationResult.model_validate(parsed)
+    except Exception:
+        with trace(name="parse_error", run_type="tool", inputs={"raw": raw, "parsed": parsed}) as t:
+            t.error = "Fast path: ValidationResult schema validation failed"
+        return None
+
+
+@traceable(run_type="chain", name="fallback_validation")
+async def _validate_fallback(
     tmdb: TMDbClient, from_actor: str, movie_title: str, to_actor: str
 ) -> ValidationResult:
-    """
-    Verify that from_actor and to_actor both appeared in movie_title.
-    Tolerates typos and misspellings — the agent uses TMDb search + web search to resolve them.
-    Returns a dict with validation result and movie metadata.
-    """
+    """Full agentic loop fallback — handles typos, ambiguous titles, web search."""
     user_message = (
         f"Verify this movie connection:\n"
         f"- Actor 1 (current): {from_actor}\n"
         f"- Movie: {movie_title}\n"
         f"- Actor 2 (proposed): {to_actor}\n\n"
-        f"Important: the player may have made minor typos or misspellings in the movie title or actor names. "
-        f"Do your best to find the intended movie and actors using fuzzy search. "
-        f"If the exact title isn't found, try common alternative spellings or use web_search to identify the correct title. "
-        f"Similarly, match actor names approximately — a last name alone or a slight misspelling should still resolve correctly.\n\n"
+        f"The player may have made minor typos or misspellings. Do your best to "
+        f"find the intended movie and actors using fuzzy search. If the exact title "
+        f"isn't found, try common alternative spellings or use web_search.\n\n"
         f"Steps:\n"
-        f"1. Search for '{movie_title}' using search_movie. If not found, try web_search to identify the correct title.\n"
+        f"1. Search for '{movie_title}' using search_movie. If not found, try web_search.\n"
         f"2. Get the cast using get_movie_cast.\n"
         f"3. Check whether '{from_actor}' AND '{to_actor}' appear (approximately) in the cast.\n"
         f"Return only the raw JSON object, nothing else."
     )
 
-    raw = await run_agent(tmdb, SYSTEM_PROMPT, user_message, ALL_TOOLS)
+    raw = await run_agent(tmdb, FALLBACK_SYSTEM, user_message, ALL_TOOLS)
 
     parsed = _extract_json(raw)
     if parsed:
         try:
             return ValidationResult.model_validate(parsed)
         except Exception:
-            logger.warning(
-                "ValidationResult failed schema validation. Parsed: %r", parsed
-            )
-            with trace(
-                name="parse_error",
-                run_type="tool",
-                inputs={"raw": raw, "parsed": parsed},
-            ) as t:
-                t.error = "ValidationResult schema validation failed"
+            logger.warning("Fallback ValidationResult failed schema validation. Parsed: %r", parsed)
+            with trace(name="parse_error", run_type="tool", inputs={"raw": raw, "parsed": parsed}) as t:
+                t.error = "Fallback: ValidationResult schema validation failed"
 
-    logger.warning("Could not parse validation result. Raw agent response: %r", raw)
+    logger.warning("Fallback could not parse validation result. Raw: %r", raw)
     with trace(name="parse_error", run_type="tool", inputs={"raw": raw}) as t:
-        t.error = "Could not extract JSON from agent response"
+        t.error = "Fallback: could not extract JSON from agent response"
     return ValidationResult(
         valid=False,
         explanation="Could not parse validation result. Please try again.",
+        confidence=Confidence.high,
     )
+
+
+@traceable(run_type="chain", name="validate_move")
+async def validate_move(
+    tmdb: TMDbClient, from_actor: str, movie_title: str, to_actor: str
+) -> ValidationResult:
+    """
+    Verify that from_actor and to_actor both appeared in movie_title.
+
+    Fast path: pre-fetch TMDb data, one Claude call, no tool use.
+    Falls back to full agentic loop when confidence is low or pre-fetch fails.
+    Strike is only counted by the caller if the final result is invalid.
+    """
+    context = await _prefetch_movie_context(tmdb, movie_title)
+
+    if context is not None:
+        result = await _validate_fast_path(from_actor, movie_title, to_actor, context)
+        if result is not None and result.confidence != Confidence.low:
+            return result
+
+    return await _validate_fallback(tmdb, from_actor, movie_title, to_actor)

--- a/cinema_game_backend/models/game.py
+++ b/cinema_game_backend/models/game.py
@@ -1,10 +1,18 @@
+from enum import Enum
 from pydantic import BaseModel
 from typing import Literal
+
+
+class Confidence(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
 
 
 class ValidationResult(BaseModel):
     valid: bool
     explanation: str
+    confidence: Confidence = Confidence.high
     movie_id: int | None = None
     movie_title: str | None = None
     movie_year: str | None = None


### PR DESCRIPTION
## Summary

- **Fast path**: pre-fetches movie + cast from TMDb (cache-friendly from PR #59), injects cast list into prompt, asks Claude to reason in a single LLM call — no tool-use round-trips
- **Confidence gate**: fast path includes `low/medium/high` confidence; `low` triggers fallback to full agentic loop
- **Strike logic**: strike only counts if the final result is invalid — if fast path returns false but fallback returns true, no strike
- **reusable-llm-provider ready**: `_call_llm_once` in `base.py` maps directly to `provider.invoke_json(prompt, schema)` — one-line swap when the library is integrated
- **Tracing preserved**: `tmdb_prefetch`, `fast_path_validation`, `fallback_validation` all traced as named spans

## Trace shape
```
validate_move (chain)
├── tmdb_prefetch (tool)
├── fast_path_validation (chain)
│   └── claude_call (llm)          ← single call, no tools
└── fallback_validation (chain)    ← only fires on low confidence
    └── agentic_loop (chain)
        ├── claude_call (llm)
        └── tmdb_* tools...
```

## Test plan
- [x] 112/112 unit tests pass
- [ ] Run a functional test and verify fast path fires in LangSmith traces
- [ ] Play a game and confirm latency improvement on move validation
- [ ] Submit an ambiguous movie title — verify fallback fires and no incorrect strike

🤖 Generated with [Claude Code](https://claude.com/claude-code)