### PR TITLE
Fix functional test assertion bug and rate-limit resilience

### DIFF
--- a/cinema_game_backend/agents/base.py
+++ b/cinema_game_backend/agents/base.py
@@ -12,7 +12,7 @@ from langsmith import traceable
 from art_graph.cinema_data_providers.tmdb.client import TMDbClient
 from ..config import MODEL, ANTHROPIC_API_KEY
 
-client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY, max_retries=6)
 
 
 @traceable(run_type="tool", name="tmdb_search_actor")
@@ -102,10 +102,8 @@ async def run_agent(
         messages.append({"role": "assistant", "content": response.content})
 
         if response.stop_reason == "end_turn":
-            for block in response.content:
-                if block.type == "text":
-                    return block.text
-            return ""
+            text_parts = [block.text for block in response.content if block.type == "text"]
+            return "\n\n".join(text_parts)
 
         if response.stop_reason == "tool_use":
             tool_results = []

--- a/cinema_game_backend/config.py
+++ b/cinema_game_backend/config.py
@@ -40,7 +40,7 @@ def create_tmdb_client() -> TMDbClient:
         )
 
 
-MODEL = "claude-sonnet-4-6"
+MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
 DB_PATH = "cinema_game.db"
 
 # Hops = number of actor→movie→actor steps.

--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -8,6 +8,7 @@ Functional tests are never run in CI — they require actual API credentials
 and external service access.
 """
 
+import asyncio
 import pytest
 from cinema_game_backend.env import load_cinema_game_env
 from cinema_game_backend.config import create_tmdb_client
@@ -17,6 +18,13 @@ from cinema_game_backend.tools.definitions import ALL_TOOLS
 
 # Load credentials from secrets/.env
 load_cinema_game_env()
+
+
+@pytest.fixture(autouse=True)
+async def throttle_between_tests():
+    """Sleep between tests to avoid Anthropic 30k tokens/min rate limit."""
+    yield
+    await asyncio.sleep(3)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- **Test assertion bug**: `run_agent` was returning the first text block on `end_turn`, but web_search responses embed an intermediate "Now let me fetch…" text block before the final answer — fixed by collecting and joining all text blocks
- **Rate limiting**: Added `max_retries=6` on the Anthropic client (was default 2) and a 3s sleep between functional tests to spread token usage within the 30k tokens/minute window
- **Model override**: `MODEL` now reads from `ANTHROPIC_MODEL` env var so you can run functional tests against Haiku (`ANTHROPIC_MODEL=claude-haiku-4-5-20251001 pytest functional_tests/`) to avoid rate limits entirely

## Test plan
- [ ] Run `pytest functional_tests/test_run_agent_loop.py -x` — `test_multi_hop_tmdb_chain` should pass
- [ ] Run full `pytest functional_tests/` — should complete without 429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)