### PR TITLE
Fix poster URL silently dropped by setdefault in fast-path validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Copy `secrets/.env.example` to `secrets/.env` and fill in your keys:
 ```
 TMDB_API_KEY=...
 ANTHROPIC_API_KEY=...
+OPENAI_API_KEY=...
+OPENROUTER_API_KEY=...
+GEMINI_API_KEY=...
 ```
 
 **TMDb cache** — one of these must be set or the app will refuse to start:
@@ -72,6 +75,30 @@ LANGCHAIN_PROJECT=cinema-game
 ```
 
 See `secrets/README.md` for more detail.
+
+### LLM experiment harness (LangSmith)
+
+Run a model matrix over Cinema Game prompt surfaces and log each model run as a LangSmith experiment:
+
+```bash
+poetry run python scripts/run_llm_experiments.py --prefix cinema-game-llm-matrix
+```
+
+Run only a subset:
+
+```bash
+poetry run python scripts/run_llm_experiments.py --models haiku_4_5,sonnet_4_5,gpt_5_mini
+```
+
+Current model aliases:
+- `haiku_4_5`
+- `sonnet_4_5`
+- `gpt_5_mini`
+- `kimi_k2`
+- `gemini_3_flash`
+- `llama_4_maverick`
+
+If a provider's canonical model id changes, set the `EXPERIMENT_MODEL_*` env vars in `secrets/.env`.
 
 ### Development with Make
 

--- a/cinema_game_backend/agents/base.py
+++ b/cinema_game_backend/agents/base.py
@@ -102,7 +102,9 @@ async def run_agent(
         messages.append({"role": "assistant", "content": response.content})
 
         if response.stop_reason == "end_turn":
-            text_parts = [block.text for block in response.content if block.type == "text"]
+            text_parts = [
+                block.text for block in response.content if block.type == "text"
+            ]
             return "\n\n".join(text_parts)
 
         if response.stop_reason == "tool_use":

--- a/cinema_game_backend/agents/validation_agent.py
+++ b/cinema_game_backend/agents/validation_agent.py
@@ -118,8 +118,10 @@ async def _validate_fast_path(
     parsed.setdefault("movie_id", movie.id)
     parsed.setdefault("movie_title", movie.title)
     parsed.setdefault("movie_year", movie.year)
-    parsed.setdefault("poster_url", movie.poster_url)
-    parsed.setdefault("backdrop_url", movie.backdrop_url)
+    # Always use TMDb ground-truth URLs — Claude returns null for these
+    # because they aren't in the prompt, so setdefault() would never fire.
+    parsed["poster_url"] = movie.poster_url
+    parsed["backdrop_url"] = movie.backdrop_url
 
     try:
         return ValidationResult.model_validate(parsed)
@@ -188,4 +190,15 @@ async def validate_move(
         if result is not None and result.confidence != Confidence.low:
             return result
 
-    return await _validate_fallback(tmdb, from_actor, movie_title, to_actor)
+    result = await _validate_fallback(tmdb, from_actor, movie_title, to_actor)
+
+    # Fallback agents don't reliably copy poster URLs from tool results.
+    # If we have a movie_id but no poster, do one cheap TMDb lookup.
+    if result.movie_id and not result.poster_url:
+        movie = await tmdb.search_movie(result.movie_title or movie_title)
+        if movie:
+            result = result.model_copy(
+                update={"poster_url": movie.poster_url, "backdrop_url": movie.backdrop_url}
+            )
+
+    return result

--- a/cinema_game_backend/agents/validation_agent.py
+++ b/cinema_game_backend/agents/validation_agent.py
@@ -126,7 +126,9 @@ async def _validate_fast_path(
     try:
         return ValidationResult.model_validate(parsed)
     except Exception:
-        with trace(name="parse_error", run_type="tool", inputs={"raw": raw, "parsed": parsed}) as t:
+        with trace(
+            name="parse_error", run_type="tool", inputs={"raw": raw, "parsed": parsed}
+        ) as t:
             t.error = "Fast path: ValidationResult schema validation failed"
         return None
 
@@ -158,8 +160,14 @@ async def _validate_fallback(
         try:
             return ValidationResult.model_validate(parsed)
         except Exception:
-            logger.warning("Fallback ValidationResult failed schema validation. Parsed: %r", parsed)
-            with trace(name="parse_error", run_type="tool", inputs={"raw": raw, "parsed": parsed}) as t:
+            logger.warning(
+                "Fallback ValidationResult failed schema validation. Parsed: %r", parsed
+            )
+            with trace(
+                name="parse_error",
+                run_type="tool",
+                inputs={"raw": raw, "parsed": parsed},
+            ) as t:
                 t.error = "Fallback: ValidationResult schema validation failed"
 
     logger.warning("Fallback could not parse validation result. Raw: %r", raw)
@@ -198,7 +206,10 @@ async def validate_move(
         movie = await tmdb.search_movie(result.movie_title or movie_title)
         if movie:
             result = result.model_copy(
-                update={"poster_url": movie.poster_url, "backdrop_url": movie.backdrop_url}
+                update={
+                    "poster_url": movie.poster_url,
+                    "backdrop_url": movie.backdrop_url,
+                }
             )
 
     return result

--- a/cinema_game_backend/config.py
+++ b/cinema_game_backend/config.py
@@ -12,6 +12,9 @@ load_cinema_game_env()
 
 TMDB_API_KEY = os.getenv("TMDB_API_KEY", "")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
 
 TMDB_CACHE_PATH = os.getenv("TMDB_CACHE_PATH")
 TMDB_CACHE_DISABLE = os.getenv("TMDB_CACHE_DISABLE", "").lower() == "true"

--- a/cinema_game_backend/experiments_llm_harness.py
+++ b/cinema_game_backend/experiments_llm_harness.py
@@ -165,7 +165,10 @@ def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) 
         payload = {
             "model": model.model,
             "input": [
-                {"role": "developer", "content": [{"type": "input_text", "text": system}]},
+                {
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": system}],
+                },
                 {"role": "user", "content": [{"type": "input_text", "text": user}]},
             ],
             "max_output_tokens": max_tokens,
@@ -253,7 +256,11 @@ def _target_for_model(model: HarnessModel, max_tokens: int):
     return _target
 
 
-def _json_shape_evaluator(inputs: dict[str, Any], outputs: dict[str, Any], reference_outputs: dict[str, Any] | None = None) -> dict[str, Any]:
+def _json_shape_evaluator(
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    reference_outputs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     del reference_outputs
     must_include = inputs.get("must_include") or []
     text = outputs.get("text", "")
@@ -278,7 +285,10 @@ _DATASET_NAME = "cinema-game-validation-prompts"
 def _ensure_dataset(client: Client) -> None:
     """Create the LangSmith dataset from built-in examples if it doesn't exist or is empty."""
     has_ds = client.has_dataset(dataset_name=_DATASET_NAME)
-    if has_ds and next(client.list_examples(dataset_name=_DATASET_NAME), None) is not None:
+    if (
+        has_ds
+        and next(client.list_examples(dataset_name=_DATASET_NAME), None) is not None
+    ):
         return
 
     ls_inputs, ls_outputs = [], []

--- a/cinema_game_backend/experiments_llm_harness.py
+++ b/cinema_game_backend/experiments_llm_harness.py
@@ -1,0 +1,342 @@
+"""LLM experiment harness for Cinema Game prompt surfaces.
+
+Runs a matrix of model providers against shared test cases and logs each model run
+as a LangSmith experiment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import anthropic
+import httpx
+from langsmith import Client
+from langsmith.evaluation import evaluate
+
+
+DEFAULT_MAX_TOKENS = 512
+
+
+@dataclass(frozen=True)
+class HarnessModel:
+    alias: str
+    provider: str
+    model: str
+    api_key_env: str
+    base_url: str | None = None
+
+
+DEFAULT_MODELS: list[HarnessModel] = [
+    HarnessModel(
+        alias="haiku_4_5",
+        provider="anthropic",
+        model=os.getenv("EXPERIMENT_MODEL_HAIKU_4_5", "claude-3-5-haiku-latest"),
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    HarnessModel(
+        alias="sonnet_4_5",
+        provider="anthropic",
+        model=os.getenv("EXPERIMENT_MODEL_SONNET_4_5", "claude-sonnet-4-5"),
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    HarnessModel(
+        alias="gpt_5_mini",
+        provider="openai_responses",
+        model=os.getenv("EXPERIMENT_MODEL_GPT_5_MINI", "gpt-5-mini"),
+        api_key_env="OPENAI_API_KEY",
+        base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+    ),
+    HarnessModel(
+        alias="kimi_k2",
+        provider="openai_compatible",
+        model=os.getenv("EXPERIMENT_MODEL_KIMI_K2", "moonshotai/kimi-k2"),
+        api_key_env="OPENROUTER_API_KEY",
+        base_url=os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
+    ),
+    HarnessModel(
+        alias="gemini_3_flash",
+        provider="gemini",
+        model=os.getenv("EXPERIMENT_MODEL_GEMINI_3_FLASH", "gemini-2.5-flash"),
+        api_key_env="GEMINI_API_KEY",
+        base_url=os.getenv(
+            "GEMINI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta"
+        ),
+    ),
+    HarnessModel(
+        alias="llama_4_maverick",
+        provider="openai_compatible",
+        model=os.getenv(
+            "EXPERIMENT_MODEL_LLAMA_4_MAVERICK", "meta-llama/llama-4-maverick"
+        ),
+        api_key_env="OPENROUTER_API_KEY",
+        base_url=os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
+    ),
+]
+
+
+def _built_in_examples() -> list[dict[str, Any]]:
+    """Core prompt surfaces matching current LLM call patterns in the app."""
+    return [
+        {
+            "inputs": {
+                "call_site": "validation_fast_path",
+                "system": (
+                    "You are a movie cast validator for a cinema connections game. "
+                    "Return ONLY raw JSON with keys: valid, explanation, confidence."
+                ),
+                "user": (
+                    "Movie: The Departed (2006)\\n"
+                    "TMDb cast: Leonardo DiCaprio, Matt Damon, Jack Nicholson, Mark Wahlberg\\n\\n"
+                    "Verify whether cast includes both 'Leonardo DiCaprio' and 'Matt Damon'."
+                ),
+            },
+            "outputs": {
+                "must_include": ["valid", "confidence"],
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "validation_fast_path",
+                "system": (
+                    "You are a movie cast validator for a cinema connections game. "
+                    "Return ONLY raw JSON with keys: valid, explanation, confidence."
+                ),
+                "user": (
+                    "Movie: The Matrix (1999)\\n"
+                    "TMDb cast: Keanu Reeves, Carrie-Anne Moss, Laurence Fishburne\\n\\n"
+                    "Verify whether cast includes both 'Keanu Reeves' and 'Tom Hanks'."
+                ),
+            },
+            "outputs": {
+                "must_include": ["valid", "confidence"],
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "fallback_style_single_turn",
+                "system": (
+                    "You are a movie trivia validator for a cinema connections game. "
+                    "Return ONLY raw JSON with keys: valid, explanation, confidence, movie_title."
+                ),
+                "user": (
+                    "Verify this connection: Brad Pitt -> 12 Years a Slave -> Michael Fassbender. "
+                    "Return only JSON."
+                ),
+            },
+            "outputs": {
+                "must_include": ["valid", "confidence", "movie_title"],
+            },
+        },
+    ]
+
+
+def _extract_text_from_openai_responses(payload: dict[str, Any]) -> str:
+    output = payload.get("output", [])
+    for item in output:
+        for content in item.get("content", []):
+            if content.get("type") in {"output_text", "text"}:
+                text = content.get("text")
+                if text:
+                    return text
+    return payload.get("output_text", "")
+
+
+def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) -> str:
+    api_key = os.getenv(model.api_key_env, "")
+    if not api_key:
+        raise RuntimeError(f"Missing API key env var: {model.api_key_env}")
+
+    if model.provider == "anthropic":
+        client = anthropic.Anthropic(api_key=api_key, max_retries=3)
+        response = client.messages.create(
+            model=model.model,
+            system=system,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": user}],
+        )
+        return "\n".join([b.text for b in response.content if b.type == "text"]).strip()
+
+    if model.provider == "openai_responses":
+        url = f"{model.base_url.rstrip('/')}/responses"
+        payload = {
+            "model": model.model,
+            "input": [
+                {"role": "developer", "content": [{"type": "input_text", "text": system}]},
+                {"role": "user", "content": [{"type": "input_text", "text": user}]},
+            ],
+            "max_output_tokens": max_tokens,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        with httpx.Client(timeout=90) as client:
+            resp = client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            return _extract_text_from_openai_responses(resp.json()).strip()
+
+    if model.provider == "openai_compatible":
+        url = f"{model.base_url.rstrip('/')}/chat/completions"
+        payload = {
+            "model": model.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": 0,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        with httpx.Client(timeout=90) as client:
+            resp = client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"].strip()
+
+    if model.provider == "gemini":
+        url = (
+            f"{model.base_url.rstrip('/')}/models/{model.model}:generateContent"
+            f"?key={api_key}"
+        )
+        payload = {
+            "system_instruction": {"parts": [{"text": system}]},
+            "contents": [{"parts": [{"text": user}]}],
+            "generationConfig": {"maxOutputTokens": max_tokens, "temperature": 0},
+        }
+        with httpx.Client(timeout=90) as client:
+            resp = client.post(url, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            candidates = data.get("candidates", [])
+            if not candidates:
+                return ""
+            parts = candidates[0].get("content", {}).get("parts", [])
+            return "\n".join(p.get("text", "") for p in parts).strip()
+
+    raise ValueError(f"Unsupported provider: {model.provider}")
+
+
+def _parse_json_or_none(text: str) -> dict[str, Any] | None:
+    try:
+        return json.loads(text)
+    except Exception:
+        return None
+
+
+def _target_for_model(model: HarnessModel, max_tokens: int):
+    def _target(inputs: dict[str, Any]) -> dict[str, Any]:
+        start = time.perf_counter()
+        output = _invoke_model(
+            model,
+            system=inputs["system"],
+            user=inputs["user"],
+            max_tokens=max_tokens,
+        )
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        parsed = _parse_json_or_none(output)
+        return {
+            "text": output,
+            "json_valid": parsed is not None,
+            "latency_ms": elapsed_ms,
+            "model_alias": model.alias,
+            "model": model.model,
+            "provider": model.provider,
+        }
+
+    return _target
+
+
+def _json_shape_evaluator(inputs: dict[str, Any], outputs: dict[str, Any], reference_outputs: dict[str, Any] | None = None) -> dict[str, Any]:
+    del reference_outputs
+    must_include = inputs.get("must_include") or []
+    text = outputs.get("text", "")
+    parsed = _parse_json_or_none(text)
+    if parsed is None:
+        return {"key": "json_shape", "score": 0, "comment": "Output is not valid JSON"}
+
+    missing = [k for k in must_include if k not in parsed]
+    if missing:
+        return {
+            "key": "json_shape",
+            "score": 0,
+            "comment": f"Missing keys: {', '.join(missing)}",
+        }
+
+    return {"key": "json_shape", "score": 1}
+
+
+_DATASET_NAME = "cinema-game-validation-prompts"
+
+
+def _ensure_dataset(client: Client) -> None:
+    """Create the LangSmith dataset from built-in examples if it doesn't exist or is empty."""
+    has_ds = client.has_dataset(dataset_name=_DATASET_NAME)
+    if has_ds and next(client.list_examples(dataset_name=_DATASET_NAME), None) is not None:
+        return
+
+    ls_inputs, ls_outputs = [], []
+    for example in _built_in_examples():
+        inputs = dict(example["inputs"])
+        inputs["must_include"] = example["outputs"]["must_include"]
+        ls_inputs.append(inputs)
+        ls_outputs.append({})
+
+    if not has_ds:
+        client.create_dataset(
+            dataset_name=_DATASET_NAME,
+            description="Cinema Game validation prompt test cases",
+        )
+    client.create_examples(
+        dataset_name=_DATASET_NAME,
+        inputs=ls_inputs,
+        outputs=ls_outputs,
+    )
+
+
+def run_matrix(
+    experiment_prefix: str,
+    selected_aliases: list[str] | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> list[str]:
+    client = Client()
+    _ensure_dataset(client)
+
+    models = DEFAULT_MODELS
+    if selected_aliases:
+        alias_set = set(selected_aliases)
+        models = [m for m in models if m.alias in alias_set]
+
+    if not models:
+        raise ValueError("No models selected for experiment run")
+
+    experiment_names: list[str] = []
+
+    for model in models:
+        result = evaluate(
+            _target_for_model(model, max_tokens=max_tokens),
+            data=_DATASET_NAME,
+            evaluators=[_json_shape_evaluator],
+            experiment_prefix=f"{experiment_prefix}-{model.alias}",
+            description=(
+                "Cinema Game LLM harness: compare per-call prompt behavior "
+                f"for {model.alias}"
+            ),
+            metadata={
+                "model_alias": model.alias,
+                "provider": model.provider,
+                "model": model.model,
+                "harness": "cinema_game_backend.experiments_llm_harness",
+            },
+            client=client,
+            max_concurrency=1,
+        )
+        experiment_names.append(result.experiment_name)
+
+    return experiment_names

--- a/cinema_game_backend/tests/test_definitions.py
+++ b/cinema_game_backend/tests/test_definitions.py
@@ -23,9 +23,9 @@ class TestTmdbTools:
         for tool in TMDB_TOOLS:
             schema = tool["input_schema"]
             for req in schema["required"]:
-                assert req in schema["properties"], (
-                    f"{tool['name']} requires '{req}' but it's not in properties"
-                )
+                assert (
+                    req in schema["properties"]
+                ), f"{tool['name']} requires '{req}' but it's not in properties"
 
 
 class TestWebSearchTool:

--- a/scripts/run_llm_experiments.py
+++ b/scripts/run_llm_experiments.py
@@ -1,0 +1,54 @@
+"""Run multi-model LLM experiments for Cinema Game and upload to LangSmith."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+# Load secrets/.env before any langsmith or anthropic clients are constructed.
+from cinema_game_backend.env import load_cinema_game_env
+load_cinema_game_env()
+
+from cinema_game_backend.experiments_llm_harness import run_matrix
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Cinema Game LLM matrix experiments")
+    parser.add_argument(
+        "--models",
+        default="",
+        help="Comma-separated model aliases (default: all)",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="cinema-game-llm-matrix",
+        help="LangSmith experiment prefix",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=512,
+        help="max output tokens per call",
+    )
+
+    args = parser.parse_args()
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+    prefix = f"{args.prefix}-{stamp}"
+    models = [m.strip() for m in args.models.split(",") if m.strip()] or None
+
+    experiment_names = run_matrix(
+        experiment_prefix=prefix,
+        selected_aliases=models,
+        max_tokens=args.max_tokens,
+    )
+
+    print("Created LangSmith experiments:")
+    for name in experiment_names:
+        print(f"- {name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_llm_experiments.py
+++ b/scripts/run_llm_experiments.py
@@ -10,7 +10,7 @@ from cinema_game_backend.env import load_cinema_game_env
 
 load_cinema_game_env()
 
-from cinema_game_backend.experiments_llm_harness import run_matrix
+from cinema_game_backend.experiments_llm_harness import run_matrix  # noqa: E402
 
 
 def main() -> int:

--- a/scripts/run_llm_experiments.py
+++ b/scripts/run_llm_experiments.py
@@ -7,13 +7,16 @@ from datetime import datetime, timezone
 
 # Load secrets/.env before any langsmith or anthropic clients are constructed.
 from cinema_game_backend.env import load_cinema_game_env
+
 load_cinema_game_env()
 
 from cinema_game_backend.experiments_llm_harness import run_matrix
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run Cinema Game LLM matrix experiments")
+    parser = argparse.ArgumentParser(
+        description="Run Cinema Game LLM matrix experiments"
+    )
     parser.add_argument(
         "--models",
         default="",

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -1,11 +1,22 @@
 TMDB_API_KEY=your_tmdb_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here
 
 # Optional: LangSmith tracing
 #LANGCHAIN_TRACING_V2=true
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 #LANGCHAIN_API_KEY=your_langsmith_api_key_here
 #LANGCHAIN_PROJECT=cinema-game
+
+# Optional: model id overrides for the experiment harness
+#EXPERIMENT_MODEL_HAIKU_4_5=claude-3-5-haiku-latest
+#EXPERIMENT_MODEL_SONNET_4_5=claude-sonnet-4-5
+#EXPERIMENT_MODEL_GPT_5_MINI=gpt-5-mini
+#EXPERIMENT_MODEL_KIMI_K2=moonshotai/kimi-k2
+#EXPERIMENT_MODEL_GEMINI_3_FLASH=gemini-2.5-flash
+#EXPERIMENT_MODEL_LLAMA_4_MAVERICK=meta-llama/llama-4-maverick
 
 # TMDb cache configuration (one of these must be set):
 # Path to SQLite cache file (enables caching):

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -13,6 +13,9 @@ cp .env.example .env
 Edit `.env` with your keys:
 - `TMDB_API_KEY`: Get from [The Movie Database (TMDb)](https://www.themoviedb.org/settings/api)
 - `ANTHROPIC_API_KEY`: Get from [Anthropic](https://console.anthropic.com/)
+- `OPENAI_API_KEY`: For GPT-5 mini
+- `OPENROUTER_API_KEY`: For Kimi K2 and Llama 4 Maverick via OpenRouter
+- `GEMINI_API_KEY`: For Gemini Flash models
 
 The `.env` file is automatically loaded by `cinema_game_backend/env.py` when the backend starts.
 


### PR DESCRIPTION
## Summary

- `setdefault()` only sets a key when it's absent, but Claude's JSON response template always includes `"poster_url": null` — so the key was always present and TMDb's real URL was silently discarded
- Fast path: force-assign `poster_url` and `backdrop_url` from the TMDb pre-fetch context (the model has no way to know these URLs anyway)
- Fallback path: after the agent loop, if `movie_id` is known but `poster_url` is still null, do a cheap `search_movie` re-fetch to backfill both fields

## Test plan

- [ ] Submit a correct move and verify the movie poster appears in the move card
- [ ] Confirm poster also appears on the win screen poster chain
- [ ] Verify fallback path (low-confidence or pre-fetch failure) still returns a poster URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)