### PR TITLE
Add comprehensive LLM eval harness for model comparison

### DIFF
--- a/cinema_game_backend/experiments_llm_harness.py
+++ b/cinema_game_backend/experiments_llm_harness.py
@@ -707,7 +707,7 @@ def run_matrix(
 
     for model in models:
         cost_row = CostRow(alias=model.alias, model=model.model)
-        evaluate(
+        result = evaluate(
             _target_for_model(model, max_tokens=max_tokens, cost_row=cost_row),
             data=_DATASET_NAME,
             evaluators=[_json_shape_evaluator, _cost_evaluator, _token_evaluator],
@@ -725,7 +725,7 @@ def run_matrix(
             client=client,
             max_concurrency=1,
         )
-        experiment_names.append(f"{experiment_prefix}-{model.alias}")
+        experiment_names.append(result.experiment_name)
         cost_rows.append(cost_row)
 
     return experiment_names, cost_rows
@@ -753,7 +753,7 @@ def run_name_match_matrix(
 
     for model in models:
         cost_row = CostRow(alias=model.alias, model=model.model)
-        evaluate(
+        result = evaluate(
             _target_for_model(model, max_tokens=max_tokens, cost_row=cost_row),
             data=_NAME_MATCH_DATASET_NAME,
             evaluators=[
@@ -778,7 +778,7 @@ def run_name_match_matrix(
             client=client,
             max_concurrency=1,
         )
-        experiment_names.append(f"{experiment_prefix}-{model.alias}")
+        experiment_names.append(result.experiment_name)
         cost_rows.append(cost_row)
 
     return experiment_names, cost_rows

--- a/cinema_game_backend/experiments_llm_harness.py
+++ b/cinema_game_backend/experiments_llm_harness.py
@@ -16,6 +16,7 @@ import anthropic
 import httpx
 from langsmith import Client
 from langsmith.evaluation import evaluate
+from langsmith.evaluation.evaluator import EvaluationResult
 
 
 DEFAULT_MAX_TOKENS = 512
@@ -34,7 +35,7 @@ DEFAULT_MODELS: list[HarnessModel] = [
     HarnessModel(
         alias="haiku_4_5",
         provider="anthropic",
-        model=os.getenv("EXPERIMENT_MODEL_HAIKU_4_5", "claude-3-5-haiku-latest"),
+        model=os.getenv("EXPERIMENT_MODEL_HAIKU_4_5", "claude-haiku-4-5-20251001"),
         api_key_env="ANTHROPIC_API_KEY",
     ),
     HarnessModel(
@@ -72,6 +73,39 @@ DEFAULT_MODELS: list[HarnessModel] = [
         model=os.getenv(
             "EXPERIMENT_MODEL_LLAMA_4_MAVERICK", "meta-llama/llama-4-maverick"
         ),
+        api_key_env="OPENROUTER_API_KEY",
+        base_url=os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
+    ),
+    HarnessModel(
+        alias="sonnet_5",
+        provider="anthropic",
+        model=os.getenv("EXPERIMENT_MODEL_SONNET_5", "claude-sonnet-5"),
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    HarnessModel(
+        alias="opus_4_8",
+        provider="anthropic",
+        model=os.getenv("EXPERIMENT_MODEL_OPUS_4_8", "claude-opus-4-8"),
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    HarnessModel(
+        alias="gpt_4o",
+        provider="openai_compatible",
+        model=os.getenv("EXPERIMENT_MODEL_GPT_4O", "openai/gpt-4o"),
+        api_key_env="OPENROUTER_API_KEY",
+        base_url=os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
+    ),
+    HarnessModel(
+        alias="gemini_25_flash",
+        provider="openai_compatible",
+        model=os.getenv("EXPERIMENT_MODEL_GEMINI_25_FLASH", "google/gemini-2.5-flash"),
+        api_key_env="OPENROUTER_API_KEY",
+        base_url=os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
+    ),
+    HarnessModel(
+        alias="deepseek_v3",
+        provider="openai_compatible",
+        model=os.getenv("EXPERIMENT_MODEL_DEEPSEEK_V3", "deepseek/deepseek-chat-v3-0324"),
         api_key_env="OPENROUTER_API_KEY",
         base_url=os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
     ),
@@ -134,6 +168,36 @@ def _built_in_examples() -> list[dict[str, Any]]:
     ]
 
 
+@dataclass(frozen=True)
+class _InvokeResult:
+    text: str
+    input_tokens: int | None
+    output_tokens: int | None
+    reported_cost_usd: float | None = None
+
+
+# Input/output price per million tokens. Update as provider pricing changes.
+# OpenRouter models use their reported cost field instead of this table.
+_PRICE_PER_M_TOKENS: dict[str, tuple[float, float]] = {
+    "claude-haiku-4-5-20251001": (0.80, 4.00),
+    "claude-sonnet-4-5": (3.00, 15.00),
+    "claude-sonnet-5": (3.00, 15.00),
+    "claude-opus-4-8": (15.00, 75.00),
+    # OpenAI direct (responses API)
+    "gpt-5-mini": (1.10, 4.40),
+}
+
+
+def _estimate_cost(model_id: str, input_tok: int | None, output_tok: int | None) -> float | None:
+    if input_tok is None or output_tok is None:
+        return None
+    prices = _PRICE_PER_M_TOKENS.get(model_id)
+    if prices is None:
+        return None
+    in_price, out_price = prices
+    return round((input_tok * in_price + output_tok * out_price) / 1_000_000, 8)
+
+
 def _extract_text_from_openai_responses(payload: dict[str, Any]) -> str:
     output = payload.get("output", [])
     for item in output:
@@ -145,7 +209,7 @@ def _extract_text_from_openai_responses(payload: dict[str, Any]) -> str:
     return payload.get("output_text", "")
 
 
-def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) -> str:
+def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) -> _InvokeResult:
     api_key = os.getenv(model.api_key_env, "")
     if not api_key:
         raise RuntimeError(f"Missing API key env var: {model.api_key_env}")
@@ -158,7 +222,12 @@ def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) 
             max_tokens=max_tokens,
             messages=[{"role": "user", "content": user}],
         )
-        return "\n".join([b.text for b in response.content if b.type == "text"]).strip()
+        text = "\n".join([b.text for b in response.content if b.type == "text"]).strip()
+        return _InvokeResult(
+            text=text,
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+        )
 
     if model.provider == "openai_responses":
         url = f"{model.base_url.rstrip('/')}/responses"
@@ -180,7 +249,13 @@ def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) 
         with httpx.Client(timeout=90) as client:
             resp = client.post(url, headers=headers, json=payload)
             resp.raise_for_status()
-            return _extract_text_from_openai_responses(resp.json()).strip()
+            data = resp.json()
+            usage = data.get("usage", {})
+            return _InvokeResult(
+                text=_extract_text_from_openai_responses(data).strip(),
+                input_tokens=usage.get("input_tokens"),
+                output_tokens=usage.get("output_tokens"),
+            )
 
     if model.provider == "openai_compatible":
         url = f"{model.base_url.rstrip('/')}/chat/completions"
@@ -201,7 +276,13 @@ def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) 
             resp = client.post(url, headers=headers, json=payload)
             resp.raise_for_status()
             data = resp.json()
-            return data["choices"][0]["message"]["content"].strip()
+            usage = data.get("usage", {})
+            return _InvokeResult(
+                text=data["choices"][0]["message"]["content"].strip(),
+                input_tokens=usage.get("prompt_tokens"),
+                output_tokens=usage.get("completion_tokens"),
+                reported_cost_usd=usage.get("cost"),
+            )
 
     if model.provider == "gemini":
         url = (
@@ -218,10 +299,16 @@ def _invoke_model(model: HarnessModel, system: str, user: str, max_tokens: int) 
             resp.raise_for_status()
             data = resp.json()
             candidates = data.get("candidates", [])
-            if not candidates:
-                return ""
-            parts = candidates[0].get("content", {}).get("parts", [])
-            return "\n".join(p.get("text", "") for p in parts).strip()
+            text = ""
+            if candidates:
+                parts = candidates[0].get("content", {}).get("parts", [])
+                text = "\n".join(p.get("text", "") for p in parts).strip()
+            meta = data.get("usageMetadata", {})
+            return _InvokeResult(
+                text=text,
+                input_tokens=meta.get("promptTokenCount"),
+                output_tokens=meta.get("candidatesTokenCount"),
+            )
 
     raise ValueError(f"Unsupported provider: {model.provider}")
 
@@ -233,21 +320,48 @@ def _parse_json_or_none(text: str) -> dict[str, Any] | None:
         return None
 
 
-def _target_for_model(model: HarnessModel, max_tokens: int):
+@dataclass
+class CostRow:
+    alias: str
+    model: str
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+    cost_source: str = "n/a"
+
+
+def _target_for_model(model: HarnessModel, max_tokens: int, cost_row: CostRow):
     def _target(inputs: dict[str, Any]) -> dict[str, Any]:
         start = time.perf_counter()
-        output = _invoke_model(
+        result = _invoke_model(
             model,
             system=inputs["system"],
             user=inputs["user"],
             max_tokens=max_tokens,
         )
         elapsed_ms = int((time.perf_counter() - start) * 1000)
-        parsed = _parse_json_or_none(output)
+        parsed = _parse_json_or_none(result.text)
+        if result.reported_cost_usd is not None:
+            cost = result.reported_cost_usd
+            cost_source = "reported"
+        else:
+            cost = _estimate_cost(model.model, result.input_tokens, result.output_tokens)
+            cost_source = "estimated" if cost is not None else "n/a"
+
+        cost_row.calls += 1
+        cost_row.input_tokens += result.input_tokens or 0
+        cost_row.output_tokens += result.output_tokens or 0
+        cost_row.cost_usd += cost or 0.0
+        cost_row.cost_source = cost_source
+
         return {
-            "text": output,
+            "text": result.text,
             "json_valid": parsed is not None,
             "latency_ms": elapsed_ms,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "estimated_cost_usd": cost,
             "model_alias": model.alias,
             "model": model.model,
             "provider": model.provider,
@@ -265,8 +379,8 @@ def _json_shape_evaluator(
     must_include = inputs.get("must_include") or []
     text = outputs.get("text", "")
     parsed = _parse_json_or_none(text)
-    if parsed is None:
-        return {"key": "json_shape", "score": 0, "comment": "Output is not valid JSON"}
+    if not isinstance(parsed, dict):
+        return {"key": "json_shape", "score": 0, "comment": "Output is not a JSON object"}
 
     missing = [k for k in must_include if k not in parsed]
     if missing:
@@ -280,6 +394,241 @@ def _json_shape_evaluator(
 
 
 _DATASET_NAME = "cinema-game-validation-prompts"
+_NAME_MATCH_DATASET_NAME = "cinema-game-name-match"
+
+# System prompt that mirrors the preamble of validation_agent.LLM_NAME_MATCH_PROMPT.
+_NM_SYSTEM = (
+    "You are matching a player-typed actor name against a movie cast list.\n"
+    "The player is playing a cinema connections game where they name actors\n"
+    "and movies to build a chain. They may use nicknames, abbreviations,\n"
+    "or informal names (e.g. 'Larry' for 'Laurence', 'Dick' for 'Richard')."
+)
+
+
+def _nm_user(cast: list[str], query: str) -> str:
+    """Build the user turn of the llm_name_match prompt from cast + query."""
+    cast_lines = "\n".join(f"- {n}" for n in cast)
+    return (
+        f"Cast list:\n{cast_lines}\n\n"
+        f'Player typed: "{query}"\n\n'
+        "If the player clearly means one of the cast members, return a JSON object:\n"
+        '  {"matched_name": "Exact Name From Cast List"}\n'
+        "If no cast member matches, return:\n"
+        '  {"matched_name": null}\n\n'
+        "Return ONLY the JSON object, nothing else."
+    )
+
+
+def _name_match_examples() -> list[dict[str, Any]]:
+    """Test cases for the llm_name_match prompt surface in validation_agent.py."""
+    matrix_cast = [
+        "Keanu Reeves", "Laurence Fishburne", "Carrie-Anne Moss",
+        "Hugo Weaving", "Joe Pantoliano",
+    ]
+    departed_cast = [
+        "Leonardo DiCaprio", "Matt Damon", "Jack Nicholson",
+        "Mark Wahlberg", "Martin Sheen", "Alec Baldwin",
+    ]
+    gwh_cast = [
+        "Matt Damon", "Robin Williams", "Ben Affleck",
+        "Stellan Skarsgård", "Minnie Driver",
+    ]
+    sls_cast = [
+        "Bradley Cooper", "Jennifer Lawrence", "Robert De Niro",
+        "Jacki Weaver", "Chris Tucker",
+    ]
+    goodfellas_cast = [
+        "Robert De Niro", "Ray Liotta", "Joe Pesci",
+        "Lorraine Bracco", "Paul Sorvino",
+    ]
+    joker_cast = [
+        "Joaquin Phoenix", "Robert De Niro", "Zazie Beetz",
+        "Frances Conroy", "Brett Cullen",
+    ]
+    shawshank_cast = [
+        "Tim Robbins", "Morgan Freeman", "Bob Gunton",
+        "William Sadler", "Clancy Brown", "James Whitmore",
+    ]
+    avengers_cast = [
+        "Robert Downey Jr.", "Chris Evans", "Chris Hemsworth",
+        "Chris Pratt", "Mark Ruffalo", "Scarlett Johansson",
+        "Benedict Cumberbatch", "Don Cheadle",
+    ]
+
+    return [
+        # --- Positive: nicknames / informal names ---
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(matrix_cast, "Larry"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Laurence Fishburne",
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(departed_cast, "Leo"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Leonardo DiCaprio",
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(gwh_cast, "Damon"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Matt Damon",
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(sls_cast, "JLaw"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Jennifer Lawrence",
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(goodfellas_cast, "Bob De Niro"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Robert De Niro",
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(joker_cast, "Joaquim Phoenix"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Joaquin Phoenix",
+            },
+        },
+        # --- Positive: exact match (fuzzy should catch this, but LLM must not regress) ---
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(departed_cast, "Jack Nicholson"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Jack Nicholson",
+            },
+        },
+        # --- Positive: honorific prefix ---
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(departed_cast, "Mr. Nicholson"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": "Jack Nicholson",
+            },
+        },
+        # --- Negative: actor not in cast ---
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(shawshank_cast, "Tom Cruise"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": None,
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(gwh_cast, "Matthew Dillon"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": None,
+            },
+        },
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(shawshank_cast, "Unknown Actor"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": None,
+            },
+        },
+        # --- Edge: ambiguous first name (three Chrises in cast — expect null) ---
+        {
+            "inputs": {
+                "call_site": "llm_name_match",
+                "system": _NM_SYSTEM,
+                "user": _nm_user(avengers_cast, "Chris"),
+                "must_include": ["matched_name"],
+                "expected_matched_name": None,
+            },
+        },
+    ]
+
+
+def _cost_evaluator(
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    reference_outputs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    del inputs, reference_outputs
+    cost = outputs.get("estimated_cost_usd")
+    if cost is None:
+        return {"key": "cost_usd", "score": None, "comment": "cost unavailable"}
+    return {"key": "cost_usd", "score": cost}
+
+
+def _token_evaluator(
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    reference_outputs: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    del inputs, reference_outputs
+    results = []
+    for key, field in (("input_tokens", "input_tokens"), ("output_tokens", "output_tokens")):
+        val = outputs.get(field)
+        results.append({"key": key, "score": val} if val is not None else {"key": key, "score": None, "comment": "unavailable"})
+    return results
+
+
+def _name_match_correctness_evaluator(
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    reference_outputs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    del reference_outputs
+    expected = inputs.get("expected_matched_name")
+    parsed = _parse_json_or_none(outputs.get("text", ""))
+    if not isinstance(parsed, dict):
+        return {"key": "name_match_correctness", "score": 0, "comment": "not a JSON object"}
+    actual = parsed.get("matched_name")
+    score = 1 if actual == expected else 0
+    comment = "" if score else f"expected={expected!r} got={actual!r}"
+    return {"key": "name_match_correctness", "score": score, "comment": comment}
+
+
+def _null_precision_evaluator(
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    reference_outputs: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Only scores negative cases (expected_matched_name is None)."""
+    del reference_outputs
+    if inputs.get("expected_matched_name") is not None:
+        return EvaluationResult(key="null_precision", score=None, comment="n/a (positive case)")
+    parsed = _parse_json_or_none(outputs.get("text", ""))
+    if not isinstance(parsed, dict):
+        return {"key": "null_precision", "score": 0, "comment": "not a JSON object"}
+    actual = parsed.get("matched_name")
+    score = 1 if actual is None else 0
+    comment = "" if score else f"hallucinated: {actual!r}"
+    return {"key": "null_precision", "score": score, "comment": comment}
 
 
 def _ensure_dataset(client: Client) -> None:
@@ -310,11 +659,38 @@ def _ensure_dataset(client: Client) -> None:
     )
 
 
+def _ensure_name_match_dataset(client: Client) -> None:
+    """Create the name-match LangSmith dataset if it doesn't exist or is empty."""
+    has_ds = client.has_dataset(dataset_name=_NAME_MATCH_DATASET_NAME)
+    if (
+        has_ds
+        and next(client.list_examples(dataset_name=_NAME_MATCH_DATASET_NAME), None) is not None
+    ):
+        return
+
+    ls_inputs = [ex["inputs"] for ex in _name_match_examples()]
+    ls_outputs = [{} for _ in ls_inputs]
+
+    if not has_ds:
+        client.create_dataset(
+            dataset_name=_NAME_MATCH_DATASET_NAME,
+            description=(
+                "Cinema Game llm_name_match eval: nickname/typo resolution "
+                "with correctness and null-precision scoring."
+            ),
+        )
+    client.create_examples(
+        dataset_name=_NAME_MATCH_DATASET_NAME,
+        inputs=ls_inputs,
+        outputs=ls_outputs,
+    )
+
+
 def run_matrix(
     experiment_prefix: str,
     selected_aliases: list[str] | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
-) -> list[str]:
+) -> tuple[list[str], list[CostRow]]:
     client = Client()
     _ensure_dataset(client)
 
@@ -327,12 +703,14 @@ def run_matrix(
         raise ValueError("No models selected for experiment run")
 
     experiment_names: list[str] = []
+    cost_rows: list[CostRow] = []
 
     for model in models:
-        result = evaluate(
-            _target_for_model(model, max_tokens=max_tokens),
+        cost_row = CostRow(alias=model.alias, model=model.model)
+        evaluate(
+            _target_for_model(model, max_tokens=max_tokens, cost_row=cost_row),
             data=_DATASET_NAME,
-            evaluators=[_json_shape_evaluator],
+            evaluators=[_json_shape_evaluator, _cost_evaluator, _token_evaluator],
             experiment_prefix=f"{experiment_prefix}-{model.alias}",
             description=(
                 "Cinema Game LLM harness: compare per-call prompt behavior "
@@ -347,6 +725,60 @@ def run_matrix(
             client=client,
             max_concurrency=1,
         )
-        experiment_names.append(result.experiment_name)
+        experiment_names.append(f"{experiment_prefix}-{model.alias}")
+        cost_rows.append(cost_row)
 
-    return experiment_names
+    return experiment_names, cost_rows
+
+
+def run_name_match_matrix(
+    experiment_prefix: str,
+    selected_aliases: list[str] | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> tuple[list[str], list[CostRow]]:
+    """Run the name-match eval matrix against the cinema-game-name-match dataset."""
+    client = Client()
+    _ensure_name_match_dataset(client)
+
+    models = DEFAULT_MODELS
+    if selected_aliases:
+        alias_set = set(selected_aliases)
+        models = [m for m in models if m.alias in alias_set]
+
+    if not models:
+        raise ValueError("No models selected for experiment run")
+
+    experiment_names: list[str] = []
+    cost_rows: list[CostRow] = []
+
+    for model in models:
+        cost_row = CostRow(alias=model.alias, model=model.model)
+        evaluate(
+            _target_for_model(model, max_tokens=max_tokens, cost_row=cost_row),
+            data=_NAME_MATCH_DATASET_NAME,
+            evaluators=[
+                _json_shape_evaluator,
+                _cost_evaluator,
+                _token_evaluator,
+                _name_match_correctness_evaluator,
+                _null_precision_evaluator,
+            ],
+            experiment_prefix=f"{experiment_prefix}-{model.alias}",
+            description=(
+                "Cinema Game llm_name_match harness: nickname/typo resolution "
+                f"correctness for {model.alias}"
+            ),
+            metadata={
+                "model_alias": model.alias,
+                "provider": model.provider,
+                "model": model.model,
+                "harness": "cinema_game_backend.experiments_llm_harness",
+                "dataset": _NAME_MATCH_DATASET_NAME,
+            },
+            client=client,
+            max_concurrency=1,
+        )
+        experiment_names.append(f"{experiment_prefix}-{model.alias}")
+        cost_rows.append(cost_row)
+
+    return experiment_names, cost_rows

--- a/scripts/run_llm_experiments.py
+++ b/scripts/run_llm_experiments.py
@@ -102,7 +102,6 @@ def main() -> int:
 
     if args.dataset == "all" and all_cost_rows:
         # Merge rows by alias for a combined total
-        from collections import defaultdict
         merged: dict[str, CostRow] = {}
         for r in all_cost_rows:
             if r.alias not in merged:

--- a/scripts/run_llm_experiments.py
+++ b/scripts/run_llm_experiments.py
@@ -10,7 +10,33 @@ from cinema_game_backend.env import load_cinema_game_env
 
 load_cinema_game_env()
 
-from cinema_game_backend.experiments_llm_harness import run_matrix  # noqa: E402
+from cinema_game_backend.experiments_llm_harness import (  # noqa: E402
+    CostRow,
+    run_matrix,
+    run_name_match_matrix,
+)
+
+_DATASET_CHOICES = ("validation", "name_match", "all")
+
+
+def _print_cost_table(rows: list[CostRow], label: str) -> None:
+    if not rows:
+        return
+    print(f"\n{'─' * 72}")
+    print(f"  Cost summary — {label}")
+    print(f"{'─' * 72}")
+    print(f"  {'Model alias':<22} {'In tok':>8} {'Out tok':>8} {'Cost (USD)':>12}  Source")
+    print(f"  {'─'*22} {'─'*8} {'─'*8} {'─'*12}  {'─'*9}")
+    total_cost = 0.0
+    for r in rows:
+        cost_str = f"${r.cost_usd:.6f}" if r.cost_usd else "n/a"
+        print(f"  {r.alias:<22} {r.input_tokens:>8,} {r.output_tokens:>8,} {cost_str:>12}  {r.cost_source}")
+        total_cost += r.cost_usd
+    print(f"  {'─'*22} {'─'*8} {'─'*8} {'─'*12}")
+    total_in = sum(r.input_tokens for r in rows)
+    total_out = sum(r.output_tokens for r in rows)
+    print(f"  {'TOTAL':<22} {total_in:>8,} {total_out:>8,} ${total_cost:>11.6f}")
+    print(f"{'─' * 72}\n")
 
 
 def main() -> int:
@@ -33,6 +59,17 @@ def main() -> int:
         default=512,
         help="max output tokens per call",
     )
+    parser.add_argument(
+        "--dataset",
+        default="all",
+        choices=_DATASET_CHOICES,
+        help=(
+            "Which dataset to evaluate against: "
+            "'validation' (json-shape), "
+            "'name_match' (nickname/typo correctness), "
+            "or 'all' (both). Default: all."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -40,15 +77,47 @@ def main() -> int:
     prefix = f"{args.prefix}-{stamp}"
     models = [m.strip() for m in args.models.split(",") if m.strip()] or None
 
-    experiment_names = run_matrix(
-        experiment_prefix=prefix,
-        selected_aliases=models,
-        max_tokens=args.max_tokens,
-    )
+    experiment_names: list[str] = []
+    all_cost_rows: list[CostRow] = []
 
-    print("Created LangSmith experiments:")
+    if args.dataset in ("validation", "all"):
+        names, cost_rows = run_matrix(
+            experiment_prefix=prefix,
+            selected_aliases=models,
+            max_tokens=args.max_tokens,
+        )
+        experiment_names += names
+        _print_cost_table(cost_rows, "validation dataset")
+        all_cost_rows += cost_rows
+
+    if args.dataset in ("name_match", "all"):
+        names, cost_rows = run_name_match_matrix(
+            experiment_prefix=f"{prefix}-nm",
+            selected_aliases=models,
+            max_tokens=args.max_tokens,
+        )
+        experiment_names += names
+        _print_cost_table(cost_rows, "name-match dataset")
+        all_cost_rows += cost_rows
+
+    if args.dataset == "all" and all_cost_rows:
+        # Merge rows by alias for a combined total
+        from collections import defaultdict
+        merged: dict[str, CostRow] = {}
+        for r in all_cost_rows:
+            if r.alias not in merged:
+                merged[r.alias] = CostRow(alias=r.alias, model=r.model)
+            m = merged[r.alias]
+            m.calls += r.calls
+            m.input_tokens += r.input_tokens
+            m.output_tokens += r.output_tokens
+            m.cost_usd += r.cost_usd
+            m.cost_source = r.cost_source
+        _print_cost_table(list(merged.values()), "ALL datasets combined")
+
+    print("LangSmith experiments:")
     for name in experiment_names:
-        print(f"- {name}")
+        print(f"  - {name}")
 
     return 0
 


### PR DESCRIPTION
## Summary

- Expands the model matrix from 6 to 11 models (adds \`sonnet_5\`, \`opus_4_8\`, \`gpt_4o\`, \`gemini_25_flash\`, \`deepseek_v3\` via the existing OpenRouter key — no new API keys required)
- Adds a second LangSmith dataset (\`cinema-game-name-match\`) with 12 test cases targeting the actual production LLM call (\`llm_name_match\` in \`validation_agent.py\`), covering nicknames, typos, honorifics, true negatives, and ambiguous names — the original dataset tested prompts that don't exist in production
- Adds \`name_match_correctness\` and \`null_precision\` evaluators, plus \`cost_usd\`/\`input_tokens\`/\`output_tokens\` metrics surfaced as evaluator scores
- Captures token counts and cost from each provider's response; prints a formatted cost summary table to the terminal after each run; adds \`--dataset\` flag to target \`validation\`, \`name_match\`, or \`all\`
- Fixes: \`haiku_4_5\` model ID (404'd), non-dict JSON crashing evaluators, \`None\` return from \`null_precision\` causing LangSmith row errors, and \`0.0\` cost treated as falsy

## LangSmith experiments (2026-07-02)

| # | Model | Validation dataset | Name-match dataset |
|---|---|---|---|
| 1 | haiku_4_5 | cinema-game-full-20260702-040849Z-haiku_4_5 | cinema-game-full-20260702-040849Z-nm-haiku_4_5 |
| 2 | sonnet_4_5 | cinema-game-full-20260702-040849Z-sonnet_4_5 | cinema-game-full-20260702-040849Z-nm-sonnet_4_5 |
| 3 | gpt_5_mini | cinema-game-full-20260702-040849Z-gpt_5_mini | cinema-game-full-20260702-040849Z-nm-gpt_5_mini |
| 4 | kimi_k2 | cinema-game-full-20260702-040849Z-kimi_k2 | cinema-game-full-20260702-040849Z-nm-kimi_k2 |
| 5 | llama_4_maverick | cinema-game-full-20260702-040849Z-llama_4_maverick | cinema-game-full-20260702-040849Z-nm-llama_4_maverick |
| 6 | sonnet_5 | cinema-game-full-20260702-040849Z-sonnet_5 | cinema-game-full-20260702-040849Z-nm-sonnet_5 |
| 7 | opus_4_8 | cinema-game-full-20260702-040849Z-opus_4_8 | cinema-game-full-20260702-040849Z-nm-opus_4_8 |
| 8 | gpt_4o | cinema-game-full-20260702-040849Z-gpt_4o | cinema-game-full-20260702-040849Z-nm-gpt_4o |
| 9 | gemini_25_flash | cinema-game-full-20260702-040849Z-gemini_25_flash | cinema-game-full-20260702-040849Z-nm-gemini_25_flash |
| 10 | deepseek_v3 | cinema-game-full-20260702-040849Z-deepseek_v3 | cinema-game-full-20260702-040849Z-nm-deepseek_v3 |

## Cost output (all datasets combined)

```
────────────────────────────────────────────────────────────────────────
  Cost summary — ALL datasets combined
────────────────────────────────────────────────────────────────────────
  Model alias              In tok  Out tok   Cost (USD)  Source
  ────────────────────── ──────── ──────── ────────────  ─────────
  haiku_4_5                 2,540      442    $0.003800  estimated
  sonnet_4_5                2,540      586    $0.016410  estimated
  gpt_5_mini                2,213    2,516    $0.013505  estimated
  kimi_k2                   2,323      322    $0.002065  reported
  llama_4_maverick          2,294      243    $0.000632  reported
  sonnet_5                  3,561      576    $0.019323  estimated
  opus_4_8                  3,561      522    $0.092565  estimated
  gpt_4o                    2,228      307    $0.008640  reported
  gemini_25_flash           2,150      280    $0.001345  reported
  deepseek_v3               2,144      861    $0.001326  reported
  ────────────────────── ──────── ──────── ────────────
  TOTAL                    25,554    6,655    $0.159610
────────────────────────────────────────────────────────────────────────
```

## Test plan

- [ ] `poetry run python scripts/run_llm_experiments.py --prefix smoke --dataset validation --models haiku_4_5,sonnet_4_5` completes without errors and prints cost table
- [ ] `poetry run python scripts/run_llm_experiments.py --prefix smoke --dataset name_match --models haiku_4_5` runs 12 examples and shows `name_match_correctness` and `null_precision` scores
- [ ] LangSmith shows `cost_usd`, `input_tokens`, `output_tokens` as metric columns in experiment view

🤖 Generated with [Claude Code](https://claude.com/claude-code)