### PR TITLE
Anchor actor by TMDb ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,14 @@ Each player move produces a `validate_move` trace with the following child spans
 
 ```
 validate_move (chain)
-├── resolve_actor (tool)   — from_actor
-│   └── llm_name_match (tool)   — only if fuzzy matching failed and LLM is available
-└── resolve_actor (tool)   — to_actor
-    └── llm_name_match (tool)   — only if fuzzy matching failed and LLM is available
+└── check_movie_candidate (tool)   — once per TMDb candidate checked; stops at the first full match
+    ├── resolve_actor (tool)   — from_actor
+    │   └── llm_name_match (tool)   — only if fuzzy matching failed and LLM is available
+    └── resolve_actor (tool)   — to_actor
+        └── llm_name_match (tool)   — only if fuzzy matching failed and LLM is available
 ```
+
+For an ambiguous title (e.g. "Batman"), `check_movie_candidate` appears once per candidate walked before a match is found — most moves show it only once, since the top-ranked candidate is checked first and the walk short-circuits on success.
 
 **Reading the traces:**
 
@@ -216,6 +219,7 @@ A recorded game is a JSON file containing a start actor, end actor, and a list o
 ```json
 {
   "start_actor": "Brad Pitt",
+  "start_actor_id": 287,
   "end_actor": "Colin Firth",
   "moves": [
     {
@@ -280,9 +284,11 @@ poetry install --with notebook
 The backend uses **FastAPI dependency injection** to provide the TMDb client and an optional LLM provider. At startup, `create_tmdb_client()` reads the cache configuration and produces either a `CachedTMDbClient` (backed by SQLAlchemy) or a plain `TMDbClient`. If an LLM API key is configured, `create_llm_provider()` creates a provider via reusable-llm-provider. Both are stored on `app.state` and injected into route handlers via `Depends()`.
 
 **Move validation** works in three stages:
-1. **TMDb lookup** — search for the movie and fetch its cast list.
+1. **TMDb lookup** — search for movies matching the title (TMDb may return multiple candidates for an ambiguous title, e.g. "Batman"). Check the top-ranked candidate's cast first; if a title is ambiguous and the top-ranked film doesn't have both actors, walk the remaining candidates in TMDb's own order until one does.
 2. **Fuzzy matching** — rapidfuzz Levenshtein distance + WRatio scoring resolves typos and minor misspellings against the cast list.
 3. **LLM fallback** (optional) — if fuzzy matching fails and an LLM provider is available, an LLM call resolves harder cases like nicknames ("Larry" → "Laurence").
+
+The chain is anchored by TMDb person id, not name. `from_actor` must match the actor established by the puzzle's start actor or the previous move by TMDb id — a cast member who merely shares that name is rejected, even if the name matches exactly. `to_actor`'s id (and profile image) are read directly off the matched cast member and become the anchor for the next move; no separate actor search is performed.
 
 The TMDb cache layer lives in the [art-graph](https://github.com/ChiPowers/artist-graph) library. It caches people, movies, and credits in three tables. The caller (this app) owns the database engine and configuration — art-graph has no opinion about which database backend is used.
 

--- a/cinema_game_backend/agents/validation_agent.py
+++ b/cinema_game_backend/agents/validation_agent.py
@@ -71,14 +71,29 @@ def _resolve_actor(query: str, cast_names: list[str], llm=None) -> ActorMatch | 
 
 @traceable(run_type="tool", name="check_movie_candidate")
 async def _check_candidate(
-    tmdb: TMDbClient, movie, from_actor: str, to_actor: str, llm
+    tmdb: TMDbClient, movie, from_actor: str, from_actor_id: int, to_actor: str, llm
 ):
-    """Fetch a candidate movie's cast and try to resolve both actors against it."""
+    """Fetch a candidate movie's cast and try to resolve both actors against it.
+
+    from_actor is anchored by TMDb id: a fuzzy name match is only accepted if
+    some cast member with that exact matched name also has the anchored id,
+    since a cast member who merely shares a name is a different person.
+    """
     cast = await tmdb.get_movie_cast(movie.id)
     cast_names = [c.name for c in cast]
+
     from_match = _resolve_actor(from_actor, cast_names, llm)
+    if from_match is not None and not any(
+        c.id == from_actor_id and c.name == from_match.matched_name for c in cast
+    ):
+        from_match = None
+
     to_match = _resolve_actor(to_actor, cast_names, llm)
-    return from_match, to_match
+    to_member = None
+    if to_match is not None:
+        to_member = next(c for c in cast if c.name == to_match.matched_name)
+
+    return from_match, to_match, to_member
 
 
 @traceable(run_type="chain", name="validate_move")
@@ -87,6 +102,8 @@ async def validate_move(
     from_actor: str,
     movie_title: str,
     to_actor: str,
+    *,
+    from_actor_id: int,
     llm=None,
 ) -> ValidationResult:
     """
@@ -94,7 +111,9 @@ async def validate_move(
 
     1. Search TMDb for movies matching the title (TMDb handles fuzzy title
        matching and ranks results by its own relevance/recency signal).
-    2. Check the top-ranked candidate's cast for both actors first.
+    2. Check the top-ranked candidate's cast for both actors first. from_actor
+       is anchored by TMDb id, not name: a cast member who merely shares
+       from_actor's name is not accepted unless their id also matches.
     3. If a title is ambiguous (shared by multiple films) and the top-ranked
        candidate doesn't have both actors, walk the remaining candidates in
        TMDb's order, up to MAX_MOVIE_SEARCH_CANDIDATES, stopping at the first
@@ -111,17 +130,22 @@ async def validate_move(
         )
 
     movie = candidates[0]
-    from_match, to_match = await _check_candidate(
-        tmdb, movie, from_actor, to_actor, llm
+    from_match, to_match, to_member = await _check_candidate(
+        tmdb, movie, from_actor, from_actor_id, to_actor, llm
     )
 
     if from_match is None or to_match is None:
         for candidate in candidates[1:MAX_MOVIE_SEARCH_CANDIDATES]:
-            candidate_from, candidate_to = await _check_candidate(
-                tmdb, candidate, from_actor, to_actor, llm
+            candidate_from, candidate_to, candidate_to_member = await _check_candidate(
+                tmdb, candidate, from_actor, from_actor_id, to_actor, llm
             )
             if candidate_from is not None and candidate_to is not None:
-                movie, from_match, to_match = candidate, candidate_from, candidate_to
+                movie, from_match, to_match, to_member = (
+                    candidate,
+                    candidate_from,
+                    candidate_to,
+                    candidate_to_member,
+                )
                 break
 
     valid = from_match is not None and to_match is not None
@@ -155,4 +179,6 @@ async def validate_move(
         to_actor_found=to_match is not None,
         from_actor_name=from_match.matched_name if from_match else None,
         to_actor_name=to_match.matched_name if to_match else None,
+        to_actor_id=to_member.id if to_member else None,
+        to_actor_profile_url=to_member.profile_url if to_member else None,
     )

--- a/cinema_game_backend/experiments/export.py
+++ b/cinema_game_backend/experiments/export.py
@@ -44,6 +44,7 @@ def export_game(game_id: str) -> RecordedGame:
         expected = ExpectedSuccess(
             movie_id=m["movie_id"],
             movie_title=m["movie_title"],
+            actor_id=m.get("to_actor_id"),
             actor_name=m["to_actor"],
         )
         moves.append(
@@ -52,6 +53,7 @@ def export_game(game_id: str) -> RecordedGame:
 
     return RecordedGame(
         start_actor=game["start_actor"]["name"],
+        start_actor_id=game["start_actor"]["id"],
         end_actor=game["end_actor"]["name"],
         moves=moves,
     )

--- a/cinema_game_backend/experiments/replay.py
+++ b/cinema_game_backend/experiments/replay.py
@@ -21,10 +21,13 @@ async def replay_move(
     tmdb: TMDbClient,
     from_actor: str,
     move: RecordedMove,
+    from_actor_id: int,
     llm=None,
 ) -> MoveResult:
     """Replay a single move and compare against the expected outcome."""
-    result = await validate_move(tmdb, from_actor, move.movie, move.actor, llm=llm)
+    result = await validate_move(
+        tmdb, from_actor, move.movie, move.actor, from_actor_id=from_actor_id, llm=llm
+    )
 
     expected_valid = move.expected.valid
     passed = result.valid == expected_valid
@@ -73,13 +76,17 @@ async def replay_game(
     """
     results = []
     current_actor = game.start_actor
+    current_actor_id = game.start_actor_id
 
     for move in game.moves:
-        result = await replay_move(tmdb, current_actor, move, llm=llm)
+        result = await replay_move(
+            tmdb, current_actor, move, from_actor_id=current_actor_id, llm=llm
+        )
         results.append(result)
 
         # Advance the chain only if the move was expected to succeed.
         if isinstance(move.expected, ExpectedSuccess):
             current_actor = move.expected.actor_name
+            current_actor_id = move.expected.actor_id
 
     return results

--- a/cinema_game_backend/models/experiment.py
+++ b/cinema_game_backend/models/experiment.py
@@ -31,5 +31,6 @@ class RecordedGame(BaseModel):
     """A complete recorded game session for regression testing."""
 
     start_actor: str
+    start_actor_id: int | None = None
     end_actor: str
     moves: list[RecordedMove]

--- a/cinema_game_backend/models/game.py
+++ b/cinema_game_backend/models/game.py
@@ -22,6 +22,8 @@ class ValidationResult(BaseModel):
     to_actor_found: bool = False
     from_actor_name: str | None = None
     to_actor_name: str | None = None
+    to_actor_id: int | None = None
+    to_actor_profile_url: str | None = None
 
 
 class Actor(BaseModel):
@@ -55,6 +57,8 @@ class Move(BaseModel):
     movie_year: str | None = None
     poster_url: str | None = None
     backdrop_url: str | None = None
+    from_actor_id: int | None = None
+    to_actor_id: int | None = None
 
 
 class GameState(BaseModel):

--- a/cinema_game_backend/routes/game.py
+++ b/cinema_game_backend/routes/game.py
@@ -96,6 +96,7 @@ async def make_move(
         raise HTTPException(status_code=400, detail="Game is already over")
 
     from_actor = game["current_actor"]["name"]
+    from_actor_id = game["current_actor"]["id"]
 
     rt = get_current_run_tree()
     if rt:
@@ -112,6 +113,7 @@ async def make_move(
         from_actor,
         body.movie,
         body.next_actor,
+        from_actor_id=from_actor_id,
         llm=llm,
         langsmith_extra={"metadata": {"game_id": game_id}},
     )
@@ -128,10 +130,14 @@ async def make_move(
             strikes=strikes,
         )
 
-    # Resolve the next actor's TMDb ID for accurate win detection.
-    # Use the canonical matched name from validation (not the raw player input)
-    # so that misspellings like "Kat Denings" resolve to "Kat Dennings".
-    new_actor = await _resolve_actor(tmdb, result.to_actor_name or body.next_actor)
+    # The next actor's TMDb ID and canonical name come straight from the cast
+    # member validate_move matched against — no separate name search needed,
+    # and no risk of that search resolving to a different person.
+    new_actor = {
+        "name": result.to_actor_name or body.next_actor,
+        "id": result.to_actor_id,
+        "profile_url": result.to_actor_profile_url,
+    }
 
     # Record the move with the canonical TMDb title
     move = Move(
@@ -143,6 +149,8 @@ async def make_move(
         movie_year=result.movie_year,
         poster_url=result.poster_url,
         backdrop_url=result.backdrop_url,
+        from_actor_id=from_actor_id,
+        to_actor_id=new_actor["id"],
     )
     game["moves"].append(move.model_dump())
 

--- a/cinema_game_backend/tests/test_export.py
+++ b/cinema_game_backend/tests/test_export.py
@@ -24,6 +24,8 @@ def sample_game_dict():
                 "movie_year": "2013",
                 "poster_url": None,
                 "backdrop_url": None,
+                "from_actor_id": 287,
+                "to_actor_id": 17288,
             },
             {
                 "from_actor": "Michael Fassbender",
@@ -34,6 +36,8 @@ def sample_game_dict():
                 "movie_year": "2016",
                 "poster_url": None,
                 "backdrop_url": None,
+                "from_actor_id": 17288,
+                "to_actor_id": 4586,
             },
         ],
         "current_actor": {"name": "Nicholas Hoult", "id": 4586},
@@ -126,12 +130,13 @@ class TestExportGame:
         assert first.expected.actor_name == "Michael Fassbender"
 
     @patch("cinema_game_backend.experiments.export.load_game")
-    def test_export_actor_id_is_none(self, mock_load, sample_game_dict):
+    def test_export_populates_actor_ids(self, mock_load, sample_game_dict):
         mock_load.return_value = sample_game_dict
         game = export_game("abc-123")
 
-        for move in game.moves:
-            assert move.expected.actor_id is None
+        assert game.start_actor_id == 287
+        assert game.moves[0].expected.actor_id == 17288
+        assert game.moves[1].expected.actor_id == 4586
 
     @patch("cinema_game_backend.experiments.export.load_game")
     def test_export_empty_game(self, mock_load, empty_game_dict):

--- a/cinema_game_backend/tests/test_replay.py
+++ b/cinema_game_backend/tests/test_replay.py
@@ -45,9 +45,34 @@ class TestReplayMove:
                 actor_name="Natalie Portman",
             ),
         )
-        result = await replay_move(mock_tmdb, "Chris Hemsworth", move)
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
         assert result.passed is True
         assert result.detail == "ok"
+
+    async def test_passes_from_actor_id_to_validate_move(self, mock_tmdb):
+        """replay_move must anchor from_actor by TMDb id, same as the live
+        game route, not just by name."""
+        move = RecordedMove(
+            movie="Thor",
+            actor="Natalie Portman",
+            expected=ExpectedSuccess(
+                movie_id=10195,
+                movie_title="Thor",
+                actor_id=2,
+                actor_name="Natalie Portman",
+            ),
+        )
+        # A homonym with the wrong id sits in the cast; only the real
+        # Chris Hemsworth (id=1) should be accepted as from_actor.
+        mock_tmdb.get_movie_cast.return_value = [
+            CastMember(id=999, name="Chris Hemsworth"),
+            CastMember(id=2, name="Natalie Portman"),
+        ]
+
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
+
+        assert result.passed is False
+        assert result.actual_valid is False
 
     async def test_expected_failure_passes(self, mock_tmdb):
         move = RecordedMove(
@@ -55,7 +80,7 @@ class TestReplayMove:
             actor="Leonardo DiCaprio",
             expected=ExpectedFailure(),
         )
-        result = await replay_move(mock_tmdb, "Chris Hemsworth", move)
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
         assert result.passed is True
         assert result.detail == "ok"
 
@@ -70,7 +95,7 @@ class TestReplayMove:
                 actor_name="Leonardo DiCaprio",
             ),
         )
-        result = await replay_move(mock_tmdb, "Chris Hemsworth", move)
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
         assert result.passed is False
         assert "Expected success but move was rejected" in result.detail
 
@@ -80,7 +105,7 @@ class TestReplayMove:
             actor="Natalie Portman",
             expected=ExpectedFailure(),
         )
-        result = await replay_move(mock_tmdb, "Chris Hemsworth", move)
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
         assert result.passed is False
         assert "Expected failure but move was accepted" in result.detail
 
@@ -95,7 +120,7 @@ class TestReplayMove:
                 actor_name="Natalie Portman",
             ),
         )
-        result = await replay_move(mock_tmdb, "Chris Hemsworth", move)
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
         assert result.passed is False
         assert "Movie ID mismatch" in result.detail
 
@@ -110,7 +135,7 @@ class TestReplayMove:
                 actor_name="Natalie Portmann",
             ),
         )
-        result = await replay_move(mock_tmdb, "Chris Hemsworth", move)
+        result = await replay_move(mock_tmdb, "Chris Hemsworth", move, from_actor_id=1)
         assert result.passed is False
         assert "Actor name mismatch" in result.detail
 
@@ -119,6 +144,7 @@ class TestReplayGame:
     async def test_full_game_replay(self, mock_tmdb):
         game = RecordedGame(
             start_actor="Chris Hemsworth",
+            start_actor_id=1,
             end_actor="Tom Hiddleston",
             moves=[
                 RecordedMove(
@@ -150,6 +176,7 @@ class TestReplayGame:
     async def test_game_with_failed_move(self, mock_tmdb):
         game = RecordedGame(
             start_actor="Chris Hemsworth",
+            start_actor_id=1,
             end_actor="Natalie Portman",
             moves=[
                 RecordedMove(
@@ -179,6 +206,7 @@ class TestReplayGame:
         the previous move's expected actor_name."""
         game = RecordedGame(
             start_actor="Chris Hemsworth",
+            start_actor_id=1,
             end_actor="Tom Hiddleston",
             moves=[
                 RecordedMove(
@@ -213,6 +241,7 @@ class TestReplayGame:
         """After a failed move, from_actor should remain the same."""
         game = RecordedGame(
             start_actor="Chris Hemsworth",
+            start_actor_id=1,
             end_actor="Natalie Portman",
             moves=[
                 RecordedMove(

--- a/cinema_game_backend/tests/test_routes.py
+++ b/cinema_game_backend/tests/test_routes.py
@@ -209,16 +209,17 @@ class TestMakeMove:
             movie_id=76203,
             movie_title="12 Years a Slave",
             movie_year="2013",
-        )
-        mock_tmdb.search_person = AsyncMock(
-            return_value=Person(name="Michael Fassbender", id=17288)
+            from_actor_found=True,
+            to_actor_found=True,
+            to_actor_name="Michael Fassbender",
+            to_actor_id=17288,
         )
 
         with patch(
             "cinema_game_backend.routes.game.validate_move",
             new_callable=AsyncMock,
             return_value=mock_validation,
-        ):
+        ) as mock_validate:
             res = client.post(
                 f"/game/{game_id}/move",
                 json={"movie": "12 Years a Slave", "next_actor": "Michael Fassbender"},
@@ -229,7 +230,10 @@ class TestMakeMove:
         assert data["valid"] is True
         assert data["game_status"] == "in_progress"
         assert data["current_actor"]["name"] == "Michael Fassbender"
+        assert data["current_actor"]["id"] == 17288
         assert data["movie_title"] == "12 Years a Slave"
+        # from_actor is anchored by the current actor's TMDb id, not just name.
+        assert mock_validate.call_args.kwargs["from_actor_id"] == 287
 
     def test_invalid_move(self, client):
         game_id = self._create_game(client)
@@ -264,9 +268,10 @@ class TestMakeMove:
             movie_id=24420,
             movie_title="A Single Man",
             movie_year="2009",
-        )
-        mock_tmdb.search_person = AsyncMock(
-            return_value=Person(name="Colin Firth", id=1891)
+            from_actor_found=True,
+            to_actor_found=True,
+            to_actor_name="Colin Firth",
+            to_actor_id=1891,
         )
 
         with patch(
@@ -301,9 +306,10 @@ class TestMakeMove:
             movie_id=1,
             movie_title="T",
             movie_year="2000",
-        )
-        mock_tmdb.search_person = AsyncMock(
-            return_value=Person(name="Colin Firth", id=1891)
+            from_actor_found=True,
+            to_actor_found=True,
+            to_actor_name="Colin Firth",
+            to_actor_id=1891,
         )
 
         with patch(
@@ -417,9 +423,10 @@ class TestUndoMove:
             movie_id=76203,
             movie_title="12 Years a Slave",
             movie_year="2013",
-        )
-        mock_tmdb.search_person = AsyncMock(
-            return_value=Person(name="Michael Fassbender", id=17288)
+            from_actor_found=True,
+            to_actor_found=True,
+            to_actor_name="Michael Fassbender",
+            to_actor_id=17288,
         )
 
         with patch(

--- a/cinema_game_backend/tests/test_validation_agent.py
+++ b/cinema_game_backend/tests/test_validation_agent.py
@@ -44,7 +44,7 @@ def mock_tmdb(thor_cast):
 class TestValidMove:
     async def test_both_actors_exact(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portman"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portman", from_actor_id=1
         )
         assert result.valid is True
         assert result.from_actor_found is True
@@ -54,7 +54,7 @@ class TestValidMove:
 
     async def test_minor_typo_accepted(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portmen"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portmen", from_actor_id=1
         )
         assert result.valid is True
         assert result.to_actor_found is True
@@ -63,7 +63,7 @@ class TestValidMove:
 class TestInvalidMove:
     async def test_actor_not_in_cast(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Leonardo DiCaprio"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Leonardo DiCaprio", from_actor_id=1
         )
         assert result.valid is False
         assert result.from_actor_found is True
@@ -72,7 +72,7 @@ class TestInvalidMove:
 
     async def test_neither_actor_in_cast(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Brad Pitt", "Thor", "Leonardo DiCaprio"
+            mock_tmdb, "Brad Pitt", "Thor", "Leonardo DiCaprio", from_actor_id=999
         )
         assert result.valid is False
         assert result.from_actor_found is False
@@ -81,7 +81,11 @@ class TestInvalidMove:
     async def test_movie_not_found(self, mock_tmdb):
         mock_tmdb.search_movies.return_value = []
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Nonexistent Movie", "Natalie Portman"
+            mock_tmdb,
+            "Chris Hemsworth",
+            "Nonexistent Movie",
+            "Natalie Portman",
+            from_actor_id=1,
         )
         assert result.valid is False
         assert "not found" in result.explanation.lower()
@@ -94,26 +98,26 @@ class TestMisspelledFinalActor:
     async def test_misspelled_name_still_valid(self, mock_tmdb):
         # "Kat Denings" -> "Kat Dennings" (distance 1)
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Kat Denings"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Kat Denings", from_actor_id=1
         )
         assert result.valid is True
         assert result.to_actor_found is True
 
     async def test_explanation_uses_canonical_name(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Kat Denings"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Kat Denings", from_actor_id=1
         )
         assert "Kat Dennings" in result.explanation
 
     async def test_to_actor_name_is_canonical(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Kat Denings"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Kat Denings", from_actor_id=1
         )
         assert result.to_actor_name == "Kat Dennings"
 
     async def test_from_actor_name_is_canonical(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemswerth", "Thor", "Kat Dennings"
+            mock_tmdb, "Chris Hemswerth", "Thor", "Kat Dennings", from_actor_id=1
         )
         assert result.from_actor_name == "Chris Hemsworth"
 
@@ -155,6 +159,7 @@ class TestLLMFallback:
             "Marlon Brando",
             "Apocalypse Now",
             "Larry Fishburne",
+            from_actor_id=1,
             llm=mock_llm,
         )
         assert result.valid is True
@@ -167,6 +172,7 @@ class TestLLMFallback:
             "Marlon Brando",
             "Apocalypse Now",
             "Larry Fishburne",
+            from_actor_id=1,
         )
         assert result.valid is False
         assert result.to_actor_found is False
@@ -179,6 +185,7 @@ class TestLLMFallback:
             "Marlon Brando",
             "Apocalypse Now",
             "Larry Fishburne",
+            from_actor_id=1,
             llm=llm,
         )
         assert result.valid is False
@@ -192,6 +199,7 @@ class TestLLMFallback:
             "Marlon Brando",
             "Apocalypse Now",
             "Larry Fishburne",
+            from_actor_id=1,
             llm=llm,
         )
         assert result.valid is False
@@ -205,6 +213,7 @@ class TestLLMFallback:
             "Marlon Brando",
             "Apocalypse Now",
             "Laurence Fishburne",
+            from_actor_id=1,
             llm=mock_llm,
         )
         assert result.valid is True
@@ -214,7 +223,7 @@ class TestLLMFallback:
 class TestMovieMetadata:
     async def test_result_includes_movie_metadata(self, mock_tmdb):
         result = await validate_move(
-            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portman"
+            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portman", from_actor_id=1
         )
         assert result.movie_id == 10195
         assert result.movie_title == "Thor"
@@ -249,7 +258,11 @@ class TestAmbiguousTitle:
         self, ambiguous_tmdb
     ):
         result = await validate_move(
-            ambiguous_tmdb, "Jack Nicholson", "Batman", "Michael Keaton"
+            ambiguous_tmdb,
+            "Jack Nicholson",
+            "Batman",
+            "Michael Keaton",
+            from_actor_id=2,
         )
         assert result.valid is True
         assert result.movie_id == 268
@@ -264,7 +277,9 @@ class TestAmbiguousTitle:
         ]
         tmdb.get_movie_cast.return_value = make_cast("Michael Keaton", "Jack Nicholson")
 
-        result = await validate_move(tmdb, "Jack Nicholson", "Batman", "Michael Keaton")
+        result = await validate_move(
+            tmdb, "Jack Nicholson", "Batman", "Michael Keaton", from_actor_id=2
+        )
 
         assert result.valid is True
         tmdb.get_movie_cast.assert_called_once_with(268)
@@ -273,7 +288,11 @@ class TestAmbiguousTitle:
         self, ambiguous_tmdb
     ):
         result = await validate_move(
-            ambiguous_tmdb, "Jack Nicholson", "Batman", "Leonardo DiCaprio"
+            ambiguous_tmdb,
+            "Jack Nicholson",
+            "Batman",
+            "Leonardo DiCaprio",
+            from_actor_id=2,
         )
         assert result.valid is False
         assert result.movie_id == 414906
@@ -301,7 +320,45 @@ class TestAmbiguousTitle:
 
         tmdb.get_movie_cast.side_effect = get_movie_cast
 
-        result = await validate_move(tmdb, "Jack Nicholson", "Batman", "Michael Keaton")
+        result = await validate_move(
+            tmdb, "Jack Nicholson", "Batman", "Michael Keaton", from_actor_id=1
+        )
 
         assert result.valid is False
         assert tmdb.get_movie_cast.call_count == 2
+
+
+class TestActorIdentityAnchor:
+    """Regression tests for the bug where the chain is anchored by actor
+    name rather than TMDb id, so a cast member who merely shares a name
+    with the anchored actor is silently accepted as a continuation of
+    the chain."""
+
+    async def test_homonym_cast_member_is_rejected_when_id_does_not_match(self):
+        tmdb = AsyncMock()
+        tmdb.search_movies.return_value = [make_movie(title="Bandits", movie_id=500)]
+        tmdb.get_movie_cast.return_value = [
+            CastMember(id=999, name="Chris Pine"),  # homonym, wrong person
+            CastMember(id=42, name="Cate Blanchett"),
+        ]
+
+        result = await validate_move(
+            tmdb,
+            from_actor="Chris Pine",
+            movie_title="Bandits",
+            to_actor="Cate Blanchett",
+            from_actor_id=64,  # the actual anchored person's TMDb id
+        )
+
+        assert result.valid is False
+        assert result.from_actor_found is False
+
+    async def test_to_actor_id_is_captured_from_cast_member(self, mock_tmdb):
+        """The next actor's TMDb id should come straight from the cast
+        member validate_move matched, not require a separate lookup."""
+        result = await validate_move(
+            mock_tmdb, "Chris Hemsworth", "Thor", "Natalie Portman", from_actor_id=1
+        )
+
+        assert result.valid is True
+        assert result.to_actor_id == 2

--- a/functional_tests/conftest.py
+++ b/functional_tests/conftest.py
@@ -35,10 +35,25 @@ def tmdb():
 def validate_move_fixture(tmdb):
     """Fixture to validate movie connections.
 
-    Returns a wrapper that injects the tmdb client into validate_move.
+    Returns a wrapper that injects the tmdb client into validate_move. If
+    from_actor_id isn't supplied, it's resolved via a real TMDb person
+    search, mirroring how a real game establishes the anchor from a prior
+    move.
     """
 
-    async def _validate(from_actor, movie_title, to_actor, **kwargs):
-        return await validate_move(tmdb, from_actor, movie_title, to_actor, **kwargs)
+    async def _validate(
+        from_actor, movie_title, to_actor, from_actor_id=None, **kwargs
+    ):
+        if from_actor_id is None:
+            person = await tmdb.search_person(from_actor)
+            from_actor_id = person.id if person else 0
+        return await validate_move(
+            tmdb,
+            from_actor,
+            movie_title,
+            to_actor,
+            from_actor_id=from_actor_id,
+            **kwargs,
+        )
 
     return _validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cinema_game_backend"
-version = "2.3.2"
+version = "2.3.3"
 description = "Cinema Game — connect actors through shared movies"
 authors = ["Chivon Powers <chivon.powers@gmail.com>", "Reuben Brasher <rkbrasher@gmail.com>"]
 license = "mit"


### PR DESCRIPTION
  The game chain was anchored by actor *name*, not TMDb id. Each move re-resolved
  `from_actor` by fuzzy-matching a name string against the current candidate
  movie's cast, with no check that the matched cast member was actually the same
  TMDb person the previous move had established. A cast member who merely shared a
  name with the anchored actor (a homonym, a spelling variant, or a different
  person entirely) would be silently accepted as a continuation of the chain.

  This PR anchors the chain by TMDb id end to end.

  ## Changes

  **`validate_move`** now requires `from_actor_id` (keyword-only). A fuzzy name 
  match against a candidate's cast is only accepted if some cast member with that 
  exact matched name also carries the anchored TMDb id. A same-named cast member 
  with a different id is treated as not found, and the existing ambiguous-title 
  candidate walk naturally continues to the next candidate.

  **`to_actor`'s id capture is fixed as part of the same root cause.** The route
  handler previously made a second, independent `search_person(name)` call to
  resolve the next actor's TMDb id — a name search that could itself resolve to a
  different person than the cast member `validate_move` had just matched.
  `ValidationResult` now carries `to_actor_id` and `to_actor_profile_url`, read
  directly off the matched cast member (TMDb already returns cast entries with
  their own person id and profile path, so no new API call is required).
  `routes/game.py` uses these directly and no longer calls `search_person` on the
  move path.

  **Persistence.** `Move` gained `from_actor_id` and `to_actor_id`, so the full
  chain of resolved TMDb ids is now recorded per move, not just the single "current
  actor" pointer.

  **Downstream wiring.** `experiments/export.py` now populates
  `ExpectedSuccess.actor_id` and `RecordedGame.start_actor_id` from the database —
  both fields already existed in the model but were always `None` in practice.
  `experiments/replay.py` threads `current_actor_id` through the replay loop the
  same way it already threaded `current_actor` by name, so replayed games are now
  anchored by id as well.

  **README** updated: a new paragraph in Architecture describing the id-anchoring
  behavior, and `start_actor_id` added to the recorded-game-format example.
  
  ## Explicitly out of scope

  `undo_move` still re-resolves the restored actor by name via `search_person`, the
  same class of issue in a different route. Not touched here; noted as a candidate
  for a follow-up look at regression/characterization test coverage more broadly.

  ## Testing
  
  - Built test-first throughout: each behavior change started from a failing test
  (a `TypeError` for the new required parameter, then a failing assertion once the
  parameter was accepted but unused) before implementation.
  - `make check` — 172 unit tests pass.
  - `make test-functional` — 11 tests pass against the real TMDb API, including the
  fixture change needed to supply a real `from_actor_id` via live lookup.
  - Verified live: played a full game end to end through the running frontend and
  backend. Confirmed in the database that both `from_actor_id`/`to_actor_id` on
  every move, and the final `current_actor_id`, match the actor TMDb ids in the
  puzzle's known solution exactly.