### PR TITLE
Docker compose

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "frontend"]
+	path = frontend
+	url = https://github.com/ChiPowers/cinema-frontend.git

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ The backend generates a puzzle: a start actor, an end actor, and a guaranteed so
 
 ## Getting started
 
+### Cloning
+
+This repo includes the [frontend](https://github.com/ChiPowers/cinema-frontend) as a git submodule at `frontend/`, pinned to a specific tagged commit. Clone with submodules included in one step:
+
+```bash
+git clone --recurse-submodules https://github.com/ChiPowers/cinema_game.git
+```
+
+If you already cloned without `--recurse-submodules` (or pulled a change that updated the submodule pointer), the `frontend/` directory will exist but be empty. Fix it with:
+
+```bash
+git submodule update --init --recursive
+```
+
+This checks out `frontend/` at the exact commit this repo's submodule pointer names — not `frontend`'s own `main` branch. To move the pin forward to a newer frontend commit, that's a deliberate `cd frontend && git checkout <ref> && cd .. && git add frontend` in this repo, not something that happens automatically on `git pull`.
+
 ### Backend
 
 Requires Python >=3.10, <3.15.
@@ -193,7 +209,7 @@ Emails are stored lowercase; the script normalizes input.
 
 ### Frontend
 
-See the [frontend repo](https://github.com/ChiPowers/cinema-frontend).
+Included as a git submodule at `frontend/` — see "Cloning" above. Also available as its own repo: [cinema-frontend](https://github.com/ChiPowers/cinema-frontend).
 
 ### Docker
 
@@ -215,7 +231,38 @@ docker run -p 8000:8000 \
 
 The API is then available at `http://localhost:8000`. The image sets `TMDB_CACHE_DISABLE=true` by default so it runs without any cache configuration; override with `TMDB_CACHE_PATH` (and a mounted volume, so the cache file persists) for cached lookups.
 
-The container's own SQLite files (`cinema_game.db`, and any TMDb cache path under `/app`) live inside the container's filesystem and are lost when the container is removed unless a volume is mounted. A `docker-compose.yml` to run this backend together with the [frontend](https://github.com/ChiPowers/cinema-frontend), with proper volumes and env file wiring, is planned as a follow-up once both repos' Dockerfiles have landed.
+The container's own SQLite files (`cinema_game.db`, and any TMDb cache path under `/app`) live inside the container's filesystem and are lost when the container is removed unless a volume is mounted.
+
+### Running both services with Docker Compose
+
+`docker-compose.yml` builds and runs this backend together with the `frontend/` submodule, wired together on a shared network.
+
+Before the first run, each service still needs its own real secrets — Compose does not create these for you:
+
+```bash
+cp secrets/.env.example secrets/.env      # fill in real values
+cp frontend/.env.example frontend/.env.local   # fill in real values
+```
+
+`NEXTAUTH_SECRET` and `INTERNAL_SECRET` must be identical in both files, per the Configuration section above.
+
+Then:
+
+```bash
+docker compose up --build
+```
+
+This builds both images, starts the backend first, waits for it to report healthy (via the image's built-in `HEALTHCHECK`), then starts the frontend. Backend is at `http://localhost:8000`, frontend at `http://localhost:3000`. Inside the Compose network, the frontend reaches the backend at `http://backend:8000` — this overrides whatever `BACKEND_URL` is set to in `frontend/.env.local`, since `localhost` would otherwise resolve to the frontend container itself, not the backend.
+
+`NEXT_PUBLIC_API_URL` is inlined into the frontend's client-side bundle at build time (browser code cannot read `frontend/.env.local` at runtime), so it comes from a build arg instead, defaulting to `http://localhost:8000`. Override it by exporting `NEXT_PUBLIC_API_URL` in your shell before running `docker compose up --build`, if the backend will not be reachable at that address from your browser.
+
+To stop everything:
+
+```bash
+docker compose down
+```
+
+Add `-v` to also remove the containers' volumes (there are none defined yet, so this currently has no additional effect — relevant once the SQLite-to-Postgres migration discussed in the deployment planning doc happens and volumes get added for persistence).
 
 ## API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./secrets/.env
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        # NEXT_PUBLIC_API_URL is inlined into the client bundle at build
+        # time, so it must be a build arg, not a runtime env var. Override
+        # by exporting NEXT_PUBLIC_API_URL before running `docker compose up`
+        # if the backend is not reachable at localhost:8000 from the browser.
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+    ports:
+      - "3000:3000"
+    env_file:
+      - ./frontend/.env.local
+    environment:
+      # Overrides whatever BACKEND_URL is set to in frontend/.env.local:
+      # inside the compose network, the frontend must reach the backend by
+      # service name, not localhost.
+      BACKEND_URL: http://backend:8000
+    depends_on:
+      backend:
+        condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cinema_game_backend"
-version = "2.3.3"
+version = "2.3.4"
 description = "Cinema Game — connect actors through shared movies"
 authors = ["Chivon Powers <chivon.powers@gmail.com>", "Reuben Brasher <rkbrasher@gmail.com>"]
 license = "mit"

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -29,3 +29,11 @@ LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 #TMDB_CACHE_PATH=/path/to/tmdb_cache.db
 # Or disable caching explicitly:
 TMDB_CACHE_DISABLE=true
+
+# ----------------------------------------------------------------------
+# Authentication (required — the app refuses to start without these)
+# ----------------------------------------------------------------------
+# Must match the frontend's NEXTAUTH_SECRET / INTERNAL_SECRET byte-for-byte.
+# Generate each with: openssl rand -base64 32
+NEXTAUTH_SECRET=
+INTERNAL_SECRET=


### PR DESCRIPTION
  Second phase of making Cinema Game portable and deployable, building on the two
  standalone Dockerfiles from the prior PRs: adds the frontend as a git submodule
  of this repo, and a `docker-compose.yml` to build and run both services together
  with one command.

  ## Changes

  **Submodule.** `frontend/` now tracks
  [cinema-frontend](https://github.com/ChiPowers/cinema-frontend), pinned to its
  `v0.2.0` tag (a detached commit, not the `main` branch — the pin only moves
  forward via a deliberate commit in this repo, not automatically on `git pull`).
  Added over HTTPS rather than SSH, since both repos are public and this avoids
  requiring submodule consumers to have SSH keys configured just to clone.

  **`docker-compose.yml`.** Builds both images; the backend starts first and the
  frontend waits for it to report healthy (via each Dockerfile's existing
  `HEALTHCHECK`) before starting, using `depends_on: condition: service_healthy`.
  Two things needed explicit handling rather than a plain `env_file` per service:

  - `NEXT_PUBLIC_API_URL` is inlined into the frontend's client bundle at build
  time, so it is supplied as a build arg (defaulting to `http://localhost:8000`,
  overridable via a shell env var), not a runtime variable.
  - `BACKEND_URL` is explicitly overridden to `http://backend:8000` in the compose
  file, since inside the Compose network the frontend must reach the backend by
  service name — `localhost` there would resolve to the frontend container itself.

  **Fixed a real gap found while wiring this up:** `secrets/.env.example` never
  listed `NEXTAUTH_SECRET`/`INTERNAL_SECRET`, even though the README has always
  instructed adding them there and the backend refuses to start without both.
  Added, matching the frontend's own `.env.example` presentation.

  **README** — new "Cloning" section under "Getting started" (`git clone
  --recurse-submodules`, and `git submodule update --init --recursive` for a clone
  or pull that left `frontend/` empty), and a new "Running both services with
  Docker Compose" section under Docker (secrets setup, `docker compose up --build`,
  `docker compose down`).

  ## Testing

  - `docker compose up --build`: both images built; backend reported healthy before
  the frontend started, confirming the health-gated startup order actually works,
  not just that it is configured.
  - With the stack running: backend `/health` → 200; frontend `/login` → 200; `POST
  /game/new` without an `Authorization` header → 422 (auth dependency still
  correctly enforced end to end through the Compose network, not just when manually
  wiring containers together as in the earlier Dockerfile PR).
  - `docker compose down` cleaned up both containers and the network fully.

  ## Version

  Bumped patch: `2.3.3` → `2.3.4`. Plan is to tag this once merged, closing the gap
  noted in the deployment-planning doc — this repo has had version bumps recorded
  in commits but no corresponding git tags until now.
