### PR TITLE
Volume for backend in docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     POETRY_VIRTUALENVS_CREATE=false \
     POETRY_NO_INTERACTION=1 \
     POETRY_VERSION=2.3.4 \
-    TMDB_CACHE_DISABLE=true
+    TMDB_CACHE_DISABLE=true \
+    DB_PATH=/data/cinema_game.db
 
 WORKDIR /app
 
@@ -29,6 +30,16 @@ RUN poetry install --only main
 
 RUN useradd --create-home --uid 1000 appuser \
     && chown -R appuser:appuser /app
+
+# DB_PATH points here rather than the app code directory so a volume can be
+# mounted at /data alone (see docker-compose.yml) without shadowing the
+# application code on every `docker compose up` — mounting a volume over
+# /app itself would pin the container to whatever code existed the first
+# time the volume was created, defeating rebuilds. This is what lets game
+# state and the beta_users table survive `docker compose down`/`up`/`--build`
+# instead of resetting every run.
+RUN mkdir -p /data && chown appuser:appuser /data
+
 USER appuser
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -256,13 +256,15 @@ This builds both images, starts the backend first, waits for it to report health
 
 `NEXT_PUBLIC_API_URL` is inlined into the frontend's client-side bundle at build time (browser code cannot read `frontend/.env.local` at runtime), so it comes from a build arg instead, defaulting to `http://localhost:8000`. Override it by exporting `NEXT_PUBLIC_API_URL` in your shell before running `docker compose up --build`, if the backend will not be reachable at that address from your browser.
 
+The backend's SQLite database (game state and the `beta_users` table) persists in a named volume (`cinema_game_db`, mounted at `/data`) across `docker compose down`/`up`/`--build`. Without it, every run would start from a completely empty database — including an empty `beta_users` table, meaning anyone added via `manage_beta_users.py` would appear to have been silently removed the next time the stack restarts.
+
 To stop everything:
 
 ```bash
 docker compose down
 ```
 
-Add `-v` to also remove the containers' volumes (there are none defined yet, so this currently has no additional effect — relevant once the SQLite-to-Postgres migration discussed in the deployment planning doc happens and volumes get added for persistence).
+Add `-v` to also remove the named volume — this deletes all game state and the beta-user allowlist, starting the next `docker compose up` completely fresh. Omit `-v` for a normal restart that keeps that data.
 
 ## API
 

--- a/cinema_game_backend/config.py
+++ b/cinema_game_backend/config.py
@@ -48,7 +48,7 @@ def create_tmdb_client() -> TMDbClient:
         )
 
 
-DB_PATH = directories.base("cinema_game.db")
+DB_PATH = os.getenv("DB_PATH", directories.base("cinema_game.db"))
 
 
 def create_llm_provider():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,14 @@ services:
       - "8000:8000"
     env_file:
       - ./secrets/.env
+    volumes:
+      # Persists game state and the beta_users table across
+      # `docker compose down`/`up`/`--build`. Without this, every run starts
+      # from a fresh, empty database — including an empty beta_users table,
+      # so anyone previously added is effectively removed on every restart.
+      # Mounted at /data (not /app) so the app code itself is never shadowed
+      # by the volume; see DB_PATH in the Dockerfile.
+      - cinema_game_db:/data
 
   frontend:
     build:
@@ -30,3 +38,6 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+
+volumes:
+  cinema_game_db:


### PR DESCRIPTION
  A colleague reported that after switching to the new `docker compose` setup,
  their email was "no longer on the beta list" — despite having been added before.
  Root cause: `docker-compose.yml` defined no volume for the backend, so every
  `docker compose up` started against a brand-new, empty `cinema_game.db`,
  including an empty `beta_users` table. Nothing removed their email; they were
  simply talking to a different, unpersisted database than whatever they had used
  previously. This affects anyone's first `docker compose up`, not just this one
  report — `init_db()` only creates an empty table, nothing seeds it.

  ## Fix

  The first approach tried — mounting a named volume directly onto the
  `cinema_game.db` file path — failed with `source ... is not directory`, a real
  Docker limitation: a named volume cannot be cleanly mounted onto a single file
  unless that exact file already exists in the image, and it did not (the database
  is created at runtime, not build time).

  Switched to the standard pattern instead:

  - `cinema_game_backend/config.py`: `DB_PATH` is now overridable via a `DB_PATH`
  env var, defaulting to the exact existing behavior when unset — no change to
  native/local dev.
  - `Dockerfile`: sets `DB_PATH=/data/cinema_game.db` for containers, and creates
  `/data` as a dedicated, empty directory owned by `appuser`.
  - `docker-compose.yml`: mounts a named volume (`cinema_game_db`) at `/data`.
  Deliberately not at `/app` — mounting a volume over the app code directory would
  pin the container to whatever code existed the first time the volume was created,
  silently defeating `--build` on every subsequent run.

  ## Testing
  
  - Reproduced the original failure first: `docker compose up --build` after this
  fix, confirmed the previous single-file-mount approach errors as described above.
  - Verified the actual fix live, not just via a plausible-looking config: added a
  test beta user, ran `docker compose down` followed by `docker compose up --build
  -d` (the same sequence as switching setups or restarting), confirmed the user was
  still present.
  - `make check` — 178 tests pass (touched `config.py`, so re-ran the full suite,
  not just a targeted subset).

  ## Not fixed here, noted for a possible follow-up

  `scripts/manage_beta_users.py` is not copied into the Docker image (the
  `Dockerfile` only copies `cinema_game_backend/`), so managing the beta list
  against a running container currently requires a Python one-liner against
  `database.py` directly rather than running the script. Left out of this PR since
  it is a separate, small concern from the persistence bug.

  ## Note for anyone who already ran the old `docker compose up`

  That run had no volume at all, so whatever was in its `beta_users` table is gone
  — anyone affected needs to be re-added one more time after pulling this fix. It
  will persist from then on.

  ## Version
  
  Not bumped — `2.3.4` (set in the prior Docker Compose PR) already reflects work
  not yet tagged.