### PR TITLE
Self-seed beta_users from BETA_SEED_EMAILS on startup

### DIFF
--- a/cinema_game_backend/config.py
+++ b/cinema_game_backend/config.py
@@ -21,6 +21,15 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
 NEXTAUTH_SECRET = os.getenv("NEXTAUTH_SECRET", "")
 INTERNAL_SECRET = os.getenv("INTERNAL_SECRET", "")
 
+# Comma-separated allowlist re-applied to the beta_users table on every
+# startup, so a database that gets wiped (container rebuild, fresh volume,
+# etc.) self-heals instead of silently locking everyone out.
+BETA_SEED_EMAILS = [
+    email.strip()
+    for email in os.getenv("BETA_SEED_EMAILS", "").split(",")
+    if email.strip()
+]
+
 TMDB_CACHE_PATH = os.getenv("TMDB_CACHE_PATH")
 TMDB_CACHE_DISABLE = os.getenv("TMDB_CACHE_DISABLE", "").lower() == "true"
 

--- a/cinema_game_backend/database.py
+++ b/cinema_game_backend/database.py
@@ -63,6 +63,11 @@ def add_beta_user(email: str):
     conn.close()
 
 
+def seed_beta_users(emails: list[str]):
+    for email in emails:
+        add_beta_user(email)
+
+
 def remove_beta_user(email: str):
     conn = get_db()
     conn.execute("DELETE FROM beta_users WHERE email = ?", (email.lower(),))

--- a/cinema_game_backend/main.py
+++ b/cinema_game_backend/main.py
@@ -8,8 +8,9 @@ from .config import (
     create_llm_provider,
     NEXTAUTH_SECRET,
     INTERNAL_SECRET,
+    BETA_SEED_EMAILS,
 )
-from .database import init_db
+from .database import init_db, seed_beta_users
 from .routes.game import router as game_router
 from .routes.auth import router as auth_router
 
@@ -27,6 +28,7 @@ async def lifespan(app: FastAPI):
             "INTERNAL_SECRET environment variable is required but not set"
         )
     init_db()
+    seed_beta_users(BETA_SEED_EMAILS)
     app.state.tmdb = create_tmdb_client()
     app.state.llm = create_llm_provider()
     if app.state.llm is None:

--- a/scripts/manage_beta_users.py
+++ b/scripts/manage_beta_users.py
@@ -9,6 +9,7 @@ Usage:
 
 import sys
 
+from cinema_game_backend.config import BETA_SEED_EMAILS
 from cinema_game_backend.database import (
     init_db,
     add_beta_user,
@@ -35,6 +36,14 @@ elif command == "remove":
     email = sys.argv[2]
     remove_beta_user(email)
     print(f"Removed: {email}")
+    seeded = {seed.strip().lower() for seed in BETA_SEED_EMAILS}
+    if email.strip().lower() in seeded:
+        print(
+            f"WARNING: {email} is still listed in BETA_SEED_EMAILS "
+            "(secrets/.env). It will be re-added automatically the next "
+            "time the app starts. Remove it from BETA_SEED_EMAILS too if "
+            "this removal should stick."
+        )
 
 elif command == "list":
     users = list_beta_users()

--- a/secrets/.env.example
+++ b/secrets/.env.example
@@ -37,3 +37,9 @@ TMDB_CACHE_DISABLE=true
 # Generate each with: openssl rand -base64 32
 NEXTAUTH_SECRET=
 INTERNAL_SECRET=
+
+# Comma-separated list of emails allowed to sign in. Re-applied to the
+# beta_users table on every app startup, so a wiped/fresh database (e.g.
+# after a container rebuild) doesn't lock everyone out — this list is the
+# actual source of truth, not the database.
+BETA_SEED_EMAILS=


### PR DESCRIPTION
## Summary
- The `beta_users` table had no persistence guarantee — a container rebuild or fresh Docker volume silently starts with an empty table, locking out everyone previously granted access with no error pointing to the actual cause (this is what happened in production: the table was empty even though a host-side dev DB still had the right emails).
- Adds `BETA_SEED_EMAILS`, a comma-separated allowlist read from `secrets/.env`, that's idempotently re-applied to `beta_users` on every app startup via `init_db()` → `seed_beta_users()`. Wiped or fresh databases self-heal instead of requiring a manual `manage_beta_users.py` run (which also isn't even copied into the Docker image today).
- `secrets/.env.example` documents the new var; real values only live in the gitignored `secrets/.env`.

## ⚠️ Deployment note
This PR only ships the *mechanism* — it does not carry any actual emails, since `secrets/.env` is gitignored and never committed. **Merging this alone will not restore login on any environment other than the machine it was tested on.** After merging, whoever manages each environment (other local setups, and wherever the production/Cloudflare-fronted instance runs) must manually add `BETA_SEED_EMAILS=<comma-separated emails>` to that environment's own `secrets/.env` and restart the backend for the fix to take effect there.

## Test plan
- [x] Rebuilt and restarted the backend container locally; confirmed `beta_users` auto-populated from `BETA_SEED_EMAILS` on startup
- [x] Confirmed `POST /auth/check-beta` returns `200` for a seeded email against the live container
- [x] CI (`python-package.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)